### PR TITLE
Support v-click animations for Slidev

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ python -m deck2video <input.md> [options]
 | `--audio-padding` | `0` | Milliseconds of silence before and after each slide's audio |
 | `--interactive`, `-i` | off | Review and approve each slide's TTS audio before continuing |
 | `--keep-temp` | off | Preserve intermediate files after rendering |
+| `--dark` | off | Render Slidev slides in dark mode (passes `--dark` to `slidev export`) |
 | `--reassemble` | off | Skip parse/render/TTS; assemble MP4 from existing temp dir files |
 | `--redo-slides` | none | Regenerate TTS for listed slides (e.g. `2,3,7`), then reassemble |
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,32 @@ layout: center
 
 ---
 
+# Key Features
+
+<v-clicks>
+
+- Fast
+- Reliable
+- Scalable
+
+</v-clicks>
+
+<!--
+Let's look at what makes this system stand out.
+[click]
+First, it's fast — sub-millisecond latency.
+[click]
+Second, reliable — 99.99% uptime.
+[click]
+Third, scalable to millions of requests.
+-->
+
+---
+
 # Questions?
 ```
+
+The `[click]` markers in speaker notes sync narration to `v-click` / `v-clicks` animations. Each marker produces a separate video segment paired with the corresponding click-state image. See [Writing slides](docs/writing-slides.md#slidev-click-animations) for full details.
 
 ## Usage
 
@@ -211,7 +235,8 @@ python -m deck2video deck.md --redo-slides 2,5 --temp-dir ./build --voice voice.
 
 This re-parses the markdown to get the current speaker notes, regenerates TTS
 audio for only the listed slides, then reassembles the full video. Slide
-numbers are 1-based and match the indices shown during a normal run.
+numbers are 1-based original slide numbers. For Slidev decks with click
+animations, all click steps for the specified slide are regenerated together.
 
 Both flags require `--temp-dir` pointing to a directory from a previous run.
 They are mutually exclusive (you can't use both at once).
@@ -269,14 +294,18 @@ key like `"Visual Studio Code"` will match before `"Code"` on its own.
 0. **Detect** -- Auto-detect the presentation format (Marp or Slidev) from
    frontmatter and content markers. Skipped when `--format` is explicit.
 1. **Parse** -- Split the Markdown on `---` delimiters, extract speaker notes
-   from `<!-- -->` comments.
-2. **Render** -- Call marp-cli (or Slidev CLI) to produce a PNG image per slide.
-3. **TTS** -- Synthesize each slide's notes with Chatterbox. Long notes are
-   split by sentence and reassembled into one WAV per slide. Slides without
+   from `<!-- -->` comments. For Slidev, expand slides into a flat list of
+   steps using `[click]` markers in the notes.
+2. **Render** -- Call marp-cli (or Slidev CLI) to produce a PNG image per step.
+   When click expansion produces more steps than slides, the Slidev CLI is
+   called with `--with-clicks`, generating one image per click state
+   (e.g. `2.png`, `2-1.png`, `2-2.png`).
+3. **TTS** -- Synthesize each step's notes with Chatterbox. Long notes are
+   split by sentence and reassembled into one WAV per step. Steps without
    notes become silent holds.
-4. **Assemble** -- Build a video segment per slide (image looped over the
+4. **Assemble** -- Build a video segment per step (image looped over the
    audio duration, or screencast video with TTS audio replacing the original
    track), then concatenate everything into the final MP4 with ffmpeg.
 
 With `--reassemble`, only step 4 runs. With `--redo-slides`, steps 1, 3
-(for selected slides only), and 4 run.
+(for selected slides and all their click steps), and 4 run.

--- a/deck2video/__main__.py
+++ b/deck2video/__main__.py
@@ -109,6 +109,20 @@ def _resolve_videos_and_fps(
     return video_paths, fps
 
 
+def _build_padding_list(steps: list, audio_padding_ms: int, with_clicks_padding_ms: int) -> list[int]:
+    """Return a per-step padding list.
+
+    Steps that start a new slide (click == 0) use ``audio_padding_ms``.
+    Steps that are within a slide (click > 0) use ``with_clicks_padding_ms``.
+    Plain ``Slide`` objects (Marp, no click attribute) always use ``audio_padding_ms``.
+    """
+    result = []
+    for step in steps:
+        click = getattr(step, "click", 0)
+        result.append(audio_padding_ms if click == 0 else with_clicks_padding_ms)
+    return result
+
+
 def _parse_slides(input_path: Path, fmt: str) -> list:
     """Parse slides using the appropriate parser for the detected format."""
     if fmt == "slidev":
@@ -145,6 +159,9 @@ def main() -> None:
                         help="Path to a JSON file mapping words to phonetic respellings")
     parser.add_argument("--audio-padding", type=int, default=0,
                         help="Milliseconds of silence before and after each slide's audio (default: 0)")
+    parser.add_argument("--with-clicks-audio-padding", type=int, default=0,
+                        help="Milliseconds of silence before and after each click-step's audio "
+                             "(default: 0; only applies when Slidev click animation steps are present)")
     parser.add_argument("--keep-temp", action="store_true",
                         help="Don't delete intermediate files after rendering")
     parser.add_argument("--format", choices=["auto", "marp", "slidev"], default="auto",
@@ -234,7 +251,9 @@ def main() -> None:
                 temp_dir=temp_dir,
                 fps=fps,
                 videos=video_paths,
-                audio_padding_ms=args.audio_padding,
+                audio_padding_ms=_build_padding_list(
+                    items, args.audio_padding, args.with_clicks_audio_padding
+                ),
             )
             logger.info("[reassemble] Assembly completed in %.2fs", time.monotonic() - t0)
             print(f"\nDone! Reassembled {len(images)} slides.")
@@ -307,7 +326,9 @@ def main() -> None:
                 temp_dir=temp_dir,
                 fps=fps,
                 videos=video_paths,
-                audio_padding_ms=args.audio_padding,
+                audio_padding_ms=_build_padding_list(
+                    all_steps, args.audio_padding, args.with_clicks_audio_padding
+                ),
             )
             logger.info("[redo] Assembly completed in %.2fs", time.monotonic() - t0)
             print(f"\nDone! Redid {len(redo_steps)} step(s) for slide(s) {','.join(str(i) for i in slide_indices)}, reassembled {len(images)} total.")
@@ -385,7 +406,9 @@ def main() -> None:
                 temp_dir=temp_dir,
                 fps=fps,
                 videos=video_paths,
-                audio_padding_ms=args.audio_padding,
+                audio_padding_ms=_build_padding_list(
+                    steps, args.audio_padding, args.with_clicks_audio_padding
+                ),
             )
             logger.info("[4/4] Assembly completed in %.2fs", time.monotonic() - t0)
 

--- a/deck2video/__main__.py
+++ b/deck2video/__main__.py
@@ -14,8 +14,9 @@ from .assembler import assemble_video
 from .detect import detect_format
 from .marp_parser import parse_marp
 from .marp_renderer import render_slides
+from .models import expand_slides_to_steps
 from .slidev_parser import parse_slidev
-from .slidev_renderer import render_slidev_slides
+from .slidev_renderer import _parse_image_stem, render_slidev_slides
 from .tts import compile_pronunciations, generate_audio_for_slides, load_pronunciations
 from .utils import check_ffmpeg, get_video_fps
 
@@ -28,9 +29,10 @@ def _discover_temp_files(temp_dir: Path) -> tuple[list[Path], list[Path]]:
     Returns (images, audio_files) sorted by index. Raises SystemExit on mismatch.
     """
     # Try Slidev v52+ style first (slides/1.png, slides/2.png, …)
+    # With --with-clicks, click steps appear as slides/2-1.png, slides/2-2.png, etc.
     slides_subdir = temp_dir / "slides"
     if slides_subdir.is_dir():
-        images = sorted(slides_subdir.glob("*.png"), key=lambda p: int(p.stem))
+        images = sorted(slides_subdir.glob("*.png"), key=lambda p: _parse_image_stem(p.stem))
     else:
         # Older Slidev style (slides.001.png) then Marp-style (no extension)
         images = sorted(temp_dir.glob("slides.[0-9][0-9][0-9].png"))
@@ -92,7 +94,8 @@ def _resolve_videos_and_fps(
                 print(f"Error: video file not found: {vp}", file=sys.stderr)
                 sys.exit(1)
             video_paths.append(vp)
-            print(f"  Slide {slide.index}: screencast → {vp.name}")
+            display_idx = slide.slide_index if hasattr(slide, "slide_index") else slide.index
+            print(f"  Slide {display_idx}: screencast → {vp.name}")
         else:
             video_paths.append(None)
 
@@ -217,7 +220,9 @@ def main() -> None:
             if fmt == "auto":
                 fmt = detect_format(str(input_path))
             slides = _parse_slides(input_path, fmt)
-            video_paths, fps = _resolve_videos_and_fps(slides, input_path, args.fps)
+            # Expand Slidev slides to steps so video_paths length matches image count
+            items = expand_slides_to_steps(slides) if fmt == "slidev" else slides
+            video_paths, fps = _resolve_videos_and_fps(items, input_path, args.fps)
             print(f"  Found {len(images)} slides, output framerate: {fps} fps")
 
             print("[reassemble] Assembling video…")
@@ -249,7 +254,13 @@ def main() -> None:
             slides = _parse_slides(input_path, fmt)
             print(f"  Found {len(slides)} slides")
 
-            # Validate requested indices
+            # For Slidev, expand to steps so indices align with temp files
+            if fmt == "slidev":
+                all_steps = expand_slides_to_steps(slides)
+            else:
+                all_steps = slides
+
+            # Validate requested indices against original slide numbers
             max_index = max(s.index for s in slides)
             for idx in slide_indices:
                 if idx > max_index:
@@ -260,12 +271,16 @@ def main() -> None:
             # Discover existing files
             images, audio_files = _discover_temp_files(temp_dir)
 
-            # Regenerate audio for selected slides only
-            redo_slides = [s for s in slides if s.index in slide_indices]
+            # Regenerate audio for selected steps only
+            # For Slidev, filter by slide_index; for Marp, filter by index
+            if fmt == "slidev":
+                redo_steps = [s for s in all_steps if s.slide_index in slide_indices]
+            else:
+                redo_steps = [s for s in all_steps if s.index in slide_indices]
             print(f"[redo] Regenerating audio for slide(s): {','.join(str(i) for i in slide_indices)}")
             t0 = time.monotonic()
             generate_audio_for_slides(
-                redo_slides,
+                redo_steps,
                 temp_dir=temp_dir,
                 voice_path=args.voice,
                 device=args.device,
@@ -281,7 +296,7 @@ def main() -> None:
 
             # Re-discover audio (files were overwritten in place)
             _, audio_files = _discover_temp_files(temp_dir)
-            video_paths, fps = _resolve_videos_and_fps(slides, input_path, args.fps)
+            video_paths, fps = _resolve_videos_and_fps(all_steps, input_path, args.fps)
 
             print("[redo] Assembling video…")
             t0 = time.monotonic()
@@ -295,7 +310,7 @@ def main() -> None:
                 audio_padding_ms=args.audio_padding,
             )
             logger.info("[redo] Assembly completed in %.2fs", time.monotonic() - t0)
-            print(f"\nDone! Redid {len(redo_slides)} slide(s), reassembled {len(images)} total.")
+            print(f"\nDone! Redid {len(redo_steps)} step(s) for slide(s) {','.join(str(i) for i in slide_indices)}, reassembled {len(images)} total.")
             print(f"Output: {output_path}")
 
         # --- Normal full pipeline ---
@@ -311,26 +326,42 @@ def main() -> None:
             t0 = time.monotonic()
             slides = _parse_slides(input_path, fmt)
             logger.info("[1/4] Parse completed in %.2fs — %d slides", time.monotonic() - t0, len(slides))
-            print(f"  Found {len(slides)} slides")
+
+            # For Slidev, expand slides into per-click steps
+            if fmt == "slidev":
+                steps = expand_slides_to_steps(slides)
+                has_clicks = len(steps) > len(slides)
+                if has_clicks:
+                    print(f"  Found {len(slides)} slides → {len(steps)} steps (click expansion)")
+                else:
+                    print(f"  Found {len(slides)} slides")
+            else:
+                steps = slides
+                has_clicks = False
+                print(f"  Found {len(slides)} slides")
 
             # Resolve video paths and auto-detect FPS from screencasts
-            video_paths, fps = _resolve_videos_and_fps(slides, input_path, args.fps)
+            video_paths, fps = _resolve_videos_and_fps(steps, input_path, args.fps)
             print(f"  Output framerate: {fps} fps")
 
             # Step 2: Render images
             print("[2/4] Rendering slide images…")
             t0 = time.monotonic()
             if fmt == "slidev":
-                images = render_slidev_slides(str(input_path), temp_dir, expected_count=len(slides))
+                images = render_slidev_slides(
+                    str(input_path), temp_dir,
+                    expected_count=len(steps),
+                    with_clicks=has_clicks,
+                )
             else:
-                images = render_slides(str(input_path), temp_dir, expected_count=len(slides))
+                images = render_slides(str(input_path), temp_dir, expected_count=len(steps))
             logger.info("[2/4] Render completed in %.2fs", time.monotonic() - t0)
 
             # Step 3: Generate audio
             print("[3/4] Generating audio…")
             t0 = time.monotonic()
             audio_files = generate_audio_for_slides(
-                slides,
+                steps,
                 temp_dir=temp_dir,
                 voice_path=args.voice,
                 device=args.device,
@@ -359,14 +390,18 @@ def main() -> None:
             logger.info("[4/4] Assembly completed in %.2fs", time.monotonic() - t0)
 
             # Summary
-            tts_count = sum(1 for s in slides if s.notes)
-            silent_count = len(slides) - tts_count
+            tts_count = sum(1 for s in steps if s.notes)
+            silent_count = len(steps) - tts_count
             video_count = sum(1 for v in video_paths if v is not None)
             parts = [f"{tts_count} narrated", f"{silent_count} silent"]
             if video_count:
                 parts.append(f"{video_count} with screencast")
-            logger.info("Done: %d slides (%s), output=%s", len(slides), ", ".join(parts), output_path)
-            print(f"\nDone! {len(slides)} slides processed ({', '.join(parts)}).")
+            if fmt == "slidev" and has_clicks:
+                logger.info("Done: %d slides (%d steps, %s), output=%s", len(slides), len(steps), ", ".join(parts), output_path)
+                print(f"\nDone! {len(slides)} slides ({len(steps)} steps) processed ({', '.join(parts)}).")
+            else:
+                logger.info("Done: %d slides (%s), output=%s", len(slides), ", ".join(parts), output_path)
+                print(f"\nDone! {len(slides)} slides processed ({', '.join(parts)}).")
             print(f"Output: {output_path}")
 
     except Exception:

--- a/deck2video/__main__.py
+++ b/deck2video/__main__.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import shutil
 import sys
@@ -123,6 +124,91 @@ def _build_padding_list(steps: list, audio_padding_ms: int, with_clicks_padding_
     return result
 
 
+def _write_manifest(steps: list, temp_dir: Path) -> None:
+    """Write steps.json recording the flat Slidev step structure.
+
+    Captures {index, slide_index, click} for every step so that a future
+    --redo-slides run can detect click-count changes and remap audio files.
+    Only called for Slidev format.
+    """
+    entries = [
+        {"index": s.index, "slide_index": s.slide_index, "click": s.click}
+        for s in steps
+    ]
+    manifest_path = temp_dir / "steps.json"
+    with open(manifest_path, "w") as f:
+        json.dump(entries, f, indent=2)
+    logger.debug("Wrote manifest with %d steps to %s", len(entries), manifest_path)
+
+
+def _read_manifest(temp_dir: Path) -> list[dict] | None:
+    """Load steps.json from temp_dir. Returns None if the file doesn't exist."""
+    manifest_path = temp_dir / "steps.json"
+    if not manifest_path.exists():
+        return None
+    with open(manifest_path) as f:
+        return json.load(f)
+
+
+def _build_audio_remap(
+    old_steps: list[dict],
+    new_steps: list,
+    redo_slide_indices: set[int],
+) -> dict[int, int]:
+    """Build a map of old audio step index → new audio step index for unchanged steps.
+
+    Steps belonging to redo'd slides are excluded (their audio will be regenerated).
+    Only steps whose position has actually shifted are included.
+    """
+    old_lookup: dict[tuple[int, int], int] = {
+        (s["slide_index"], s["click"]): s["index"]
+        for s in old_steps
+        if s["slide_index"] not in redo_slide_indices
+    }
+    rename_map: dict[int, int] = {}
+    for new_step in new_steps:
+        if new_step.slide_index not in redo_slide_indices:
+            key = (new_step.slide_index, new_step.click)
+            old_idx = old_lookup.get(key)
+            if old_idx is not None and old_idx != new_step.index:
+                rename_map[old_idx] = new_step.index
+    return rename_map
+
+
+def _apply_audio_renames(
+    rename_map: dict[int, int],
+    old_steps: list[dict],
+    redo_slide_indices: set[int],
+    temp_dir: Path,
+) -> None:
+    """Rename audio files for shifted unchanged steps; delete audio for redo'd steps.
+
+    Uses two-pass staging (rename to .tmp first, then to final names) to avoid
+    collisions when file A must move to position B while B moves to position C.
+    """
+    # Pass 1: Stage files that need renaming to .tmp names
+    for old_idx in rename_map:
+        src = temp_dir / f"audio_{old_idx:03d}.wav"
+        if src.exists():
+            src.rename(temp_dir / f"audio_{old_idx:03d}.wav.tmp")
+            logger.debug("Staged audio_%03d.wav → .tmp", old_idx)
+
+    # Delete audio files belonging to redo'd steps (TTS will create fresh ones)
+    for s in old_steps:
+        if s["slide_index"] in redo_slide_indices:
+            old_file = temp_dir / f"audio_{s['index']:03d}.wav"
+            if old_file.exists():
+                old_file.unlink()
+                logger.debug("Deleted redo'd audio_%03d.wav", s["index"])
+
+    # Pass 2: Move staged files to their final positions
+    for old_idx, new_idx in rename_map.items():
+        tmp = temp_dir / f"audio_{old_idx:03d}.wav.tmp"
+        if tmp.exists():
+            tmp.rename(temp_dir / f"audio_{new_idx:03d}.wav")
+            logger.debug("Moved audio_%03d.wav.tmp → audio_%03d.wav", old_idx, new_idx)
+
+
 def _parse_slides(input_path: Path, fmt: str) -> list:
     """Parse slides using the appropriate parser for the detected format."""
     if fmt == "slidev":
@@ -168,6 +254,9 @@ def main() -> None:
                         help="Presentation format: auto, marp, or slidev (default: auto)")
     parser.add_argument("--interactive", "-i", action="store_true",
                         help="Review and approve each slide's TTS audio before continuing")
+    parser.add_argument("--dark", action="store_true",
+                        help="Render Slidev slides in dark mode (passes --dark to slidev export; "
+                             "ignored for Marp presentations)")
 
     rerun_group = parser.add_mutually_exclusive_group()
     rerun_group.add_argument("--reassemble", action="store_true",
@@ -262,6 +351,7 @@ def main() -> None:
         # --- Redo-slides mode ---
         elif args.redo_slides:
             slide_indices = _parse_slide_list(args.redo_slides)
+            slide_indices_set = set(slide_indices)
 
             # Parse to get speaker notes
             fmt = args.format
@@ -287,15 +377,100 @@ def main() -> None:
                           file=sys.stderr)
                     sys.exit(1)
 
+            # For Slidev: detect click-count changes via manifest
+            if fmt == "slidev":
+                manifest = _read_manifest(temp_dir)
+                click_changed = False
+                if manifest is not None:
+                    old_counts: dict[int, int] = {}
+                    for s in manifest:
+                        si = s["slide_index"]
+                        if si in slide_indices_set:
+                            old_counts[si] = old_counts.get(si, 0) + 1
+                    new_counts: dict[int, int] = {}
+                    for s in all_steps:
+                        if s.slide_index in slide_indices_set:
+                            new_counts[s.slide_index] = new_counts.get(s.slide_index, 0) + 1
+                    click_changed = old_counts != new_counts
+
+                if click_changed:
+                    print(f"[redo] Click structure changed for slide(s) {','.join(str(i) for i in slide_indices)} — remapping audio and re-rendering images…")
+
+                    # Remap unchanged audio files to their new positions; delete redo'd ones
+                    rename_map = _build_audio_remap(manifest, all_steps, slide_indices_set)
+                    _apply_audio_renames(rename_map, manifest, slide_indices_set, temp_dir)
+
+                    # Clean and re-render all slide images (Slidev always exports the full deck)
+                    slides_dir = temp_dir / "slides"
+                    if slides_dir.exists():
+                        shutil.rmtree(slides_dir)
+                    has_clicks = len(all_steps) > len(slides)
+                    print("[redo] Re-rendering slide images…")
+                    t0 = time.monotonic()
+                    images = render_slidev_slides(
+                        str(input_path), temp_dir,
+                        expected_count=len(all_steps),
+                        with_clicks=has_clicks,
+                        dark=args.dark,
+                    )
+                    logger.info("[redo] Re-render completed in %.2fs", time.monotonic() - t0)
+
+                    # Regenerate TTS for all steps of the redo'd slides
+                    redo_steps = [s for s in all_steps if s.slide_index in slide_indices_set]
+                    print(f"[redo] Regenerating audio for slide(s): {','.join(str(i) for i in slide_indices)}")
+                    t0 = time.monotonic()
+                    generate_audio_for_slides(
+                        redo_steps,
+                        temp_dir=temp_dir,
+                        voice_path=args.voice,
+                        device=args.device,
+                        exaggeration=args.exaggeration,
+                        cfg_weight=args.cfg_weight,
+                        temperature=args.temperature,
+                        hold_duration=args.hold_duration,
+                        pronunciations=pronunciations,
+                        interactive=args.interactive,
+                        language=args.language,
+                    )
+                    logger.info("[redo] Audio regeneration completed in %.2fs", time.monotonic() - t0)
+
+                    # All files now in place — discover and assemble
+                    images, audio_files = _discover_temp_files(temp_dir)
+                    video_paths, fps = _resolve_videos_and_fps(all_steps, input_path, args.fps)
+
+                    print("[redo] Assembling video…")
+                    t0 = time.monotonic()
+                    assemble_video(
+                        images,
+                        audio_files,
+                        output_path,
+                        temp_dir=temp_dir,
+                        fps=fps,
+                        videos=video_paths,
+                        audio_padding_ms=_build_padding_list(
+                            all_steps, args.audio_padding, args.with_clicks_audio_padding
+                        ),
+                    )
+                    logger.info("[redo] Assembly completed in %.2fs", time.monotonic() - t0)
+
+                    _write_manifest(all_steps, temp_dir)
+                    print(f"\nDone! Redid {len(redo_steps)} step(s) for slide(s) {','.join(str(i) for i in slide_indices)} (click structure changed), reassembled {len(images)} total.")
+                    print(f"Output: {output_path}")
+                    return
+
+                elif manifest is None:
+                    print("  Note: no steps.json manifest found; cannot detect click-count changes. Re-run the full pipeline if click counts have changed.")
+
+            # --- Original redo path (no click change, or Marp) ---
             # Discover existing files
             images, audio_files = _discover_temp_files(temp_dir)
 
             # Regenerate audio for selected steps only
             # For Slidev, filter by slide_index; for Marp, filter by index
             if fmt == "slidev":
-                redo_steps = [s for s in all_steps if s.slide_index in slide_indices]
+                redo_steps = [s for s in all_steps if s.slide_index in slide_indices_set]
             else:
-                redo_steps = [s for s in all_steps if s.index in slide_indices]
+                redo_steps = [s for s in all_steps if s.index in slide_indices_set]
             print(f"[redo] Regenerating audio for slide(s): {','.join(str(i) for i in slide_indices)}")
             t0 = time.monotonic()
             generate_audio_for_slides(
@@ -331,6 +506,11 @@ def main() -> None:
                 ),
             )
             logger.info("[redo] Assembly completed in %.2fs", time.monotonic() - t0)
+
+            # Update manifest for Slidev (creates it if the original run pre-dated this feature)
+            if fmt == "slidev":
+                _write_manifest(all_steps, temp_dir)
+
             print(f"\nDone! Redid {len(redo_steps)} step(s) for slide(s) {','.join(str(i) for i in slide_indices)}, reassembled {len(images)} total.")
             print(f"Output: {output_path}")
 
@@ -356,6 +536,7 @@ def main() -> None:
                     print(f"  Found {len(slides)} slides → {len(steps)} steps (click expansion)")
                 else:
                     print(f"  Found {len(slides)} slides")
+                _write_manifest(steps, temp_dir)
             else:
                 steps = slides
                 has_clicks = False
@@ -373,6 +554,7 @@ def main() -> None:
                     str(input_path), temp_dir,
                     expected_count=len(steps),
                     with_clicks=has_clicks,
+                    dark=args.dark,
                 )
             else:
                 images = render_slides(str(input_path), temp_dir, expected_count=len(steps))

--- a/deck2video/assembler.py
+++ b/deck2video/assembler.py
@@ -137,20 +137,29 @@ def assemble_video(
     temp_dir: Path,
     fps: int,
     videos: list[Path | None] | None = None,
-    audio_padding_ms: int = 0,
+    audio_padding_ms: int | list[int] = 0,
 ) -> None:
-    """Build per-slide segments and concatenate into the final MP4."""
+    """Build per-slide segments and concatenate into the final MP4.
+
+    ``audio_padding_ms`` can be a scalar (applied to every segment) or a list
+    of per-segment values (must match the number of images).
+    """
     if videos is None:
         videos = [None] * len(images)
 
+    if isinstance(audio_padding_ms, list):
+        padding_per_step = audio_padding_ms
+    else:
+        padding_per_step = [audio_padding_ms] * len(images)
+
     segments: list[Path] = []
-    for i, (img, aud, vid) in enumerate(zip(images, audio_files, videos), start=1):
+    for i, (img, aud, vid, pad) in enumerate(zip(images, audio_files, videos, padding_per_step), start=1):
         if vid is not None:
             print(f"  Encoding video segment {i}/{len(images)} ({vid.name})…")
-            seg = _make_video_segment(i, vid, aud, temp_dir, fps, audio_padding_ms)
+            seg = _make_video_segment(i, vid, aud, temp_dir, fps, pad)
         else:
             print(f"  Encoding segment {i}/{len(images)}…")
-            seg = _make_segment(i, img, aud, temp_dir, fps, audio_padding_ms)
+            seg = _make_segment(i, img, aud, temp_dir, fps, pad)
         segments.append(seg)
 
     # Write concat list

--- a/deck2video/models.py
+++ b/deck2video/models.py
@@ -19,3 +19,67 @@ COMMENT_RE = re.compile(r"<!--(.*?)-->", re.DOTALL)
 
 # Video directive: <!-- video: path/to/file.mov -->
 VIDEO_RE = re.compile(r"^\s*video:\s*(.+?)\s*$", re.IGNORECASE)
+
+# Click marker: [click] on its own line (case-insensitive)
+CLICK_RE = re.compile(r"^\s*\[click\]\s*$", re.MULTILINE | re.IGNORECASE)
+
+
+def split_notes_on_clicks(notes: str | None) -> list[str | None]:
+    """Split notes text on [click] markers.
+
+    Returns a list where each element is either a text fragment or None
+    (for empty/whitespace-only fragments). None input returns [None].
+    Notes without [click] return a single-element list.
+    """
+    if notes is None:
+        return [None]
+    fragments = CLICK_RE.split(notes)
+    result = []
+    for f in fragments:
+        stripped = f.strip()
+        result.append(stripped if stripped else None)
+    return result
+
+
+@dataclass
+class Step:
+    index: int          # sequential 1-based position in flat list (for file naming)
+    slide_index: int    # original 1-based slide number
+    click: int          # 0 = initial state, 1 = after click 1, etc.
+    notes: str | None
+    video: str | None = None
+
+
+def expand_slides_to_steps(slides: list[Slide]) -> list[Step]:
+    """Expand a list of slides into a flat list of Steps.
+
+    Each [click] marker in a slide's notes creates an additional step.
+    Video slides produce exactly one step (no click expansion).
+    """
+    steps: list[Step] = []
+    step_index = 1
+    for slide in slides:
+        if slide.video is not None:
+            # Video slides: one step only, strip [click] markers from notes
+            notes = slide.notes
+            if notes is not None:
+                notes = CLICK_RE.sub("", notes).strip() or None
+            steps.append(Step(
+                index=step_index,
+                slide_index=slide.index,
+                click=0,
+                notes=notes,
+                video=slide.video,
+            ))
+            step_index += 1
+        else:
+            fragments = split_notes_on_clicks(slide.notes)
+            for click, fragment in enumerate(fragments):
+                steps.append(Step(
+                    index=step_index,
+                    slide_index=slide.index,
+                    click=click,
+                    notes=fragment,
+                ))
+                step_index += 1
+    return steps

--- a/deck2video/slidev_renderer.py
+++ b/deck2video/slidev_renderer.py
@@ -24,12 +24,31 @@ def check_slidev_cli() -> None:
         sys.exit(1)
 
 
+def _parse_image_stem(stem: str) -> tuple[int, int]:
+    """Parse a slide image stem into a (slide, click) sort key.
+
+    Handles both naming conventions produced by different Slidev versions:
+
+    Old (pre-v52): ``'3'`` → ``(3, 0)``, ``'3-1'`` → ``(3, 1)``
+    New (v52+):    ``'003-01'`` → ``(3, 1)``, ``'003-02'`` → ``(3, 2)``
+
+    Both sort correctly: initial state always has the lowest click key for a
+    given slide number, and subsequent click states are ordered numerically.
+    """
+    if "-" in stem:
+        slide_part, click_part = stem.split("-", 1)
+        return (int(slide_part), int(click_part))
+    return (int(stem), 0)
+
+
 def render_slidev_slides(
-    input_md: str, temp_dir: Path, expected_count: int
+    input_md: str, temp_dir: Path, expected_count: int, with_clicks: bool = False
 ) -> list[Path]:
     """Export a Slidev deck to PNG images.
 
-    Returns a sorted list of image paths.
+    Returns a sorted list of image paths. When *with_clicks* is True the
+    ``--with-clicks`` flag is appended to the export command so that Slidev
+    produces one image per click step (e.g. ``2.png``, ``2-1.png``, …).
     """
     check_slidev_cli()
 
@@ -48,6 +67,9 @@ def render_slidev_slides(
         "--output", str(output_stem),
     ]
 
+    if with_clicks:
+        cmd.append("--with-clicks")
+
     logger.debug("slidev command: %s", " ".join(cmd))
     print(f"  Running: {' '.join(cmd)}")
     result = subprocess.run(cmd, stderr=subprocess.PIPE, text=True)
@@ -57,19 +79,26 @@ def render_slidev_slides(
         raise RuntimeError(f"slidev export exited with code {result.returncode}")
 
     # Slidev export produces a slides/ subdirectory with 1.png, 2.png, …
-    # Sort numerically so slide 10 comes after 9, not after 1.
+    # When --with-clicks is used, click steps appear as 2-1.png, 2-2.png, etc.
+    # Sort numerically so slide 10 comes after 9, and click steps are ordered.
     images = sorted(
         (temp_dir / "slides").glob("*.png"),
-        key=lambda p: int(p.stem),
+        key=lambda p: _parse_image_stem(p.stem),
     )
     logger.debug("Rendered %d image(s): %s", len(images), images)
 
     if len(images) != expected_count:
         print(
-            f"Error: parsed {expected_count} slides but slidev export produced "
-            f"{len(images)} images.",
+            f"Error: expected {expected_count} step(s) but slidev export produced "
+            f"{len(images)} image(s).",
             file=sys.stderr,
         )
+        if with_clicks:
+            print(
+                "  Hint: verify that the number of [click] markers in your speaker notes "
+                "matches the v-click directives in each slide.",
+                file=sys.stderr,
+            )
         print("  Images found:", file=sys.stderr)
         for img in images:
             print(f"    {img}", file=sys.stderr)

--- a/deck2video/slidev_renderer.py
+++ b/deck2video/slidev_renderer.py
@@ -42,13 +42,16 @@ def _parse_image_stem(stem: str) -> tuple[int, int]:
 
 
 def render_slidev_slides(
-    input_md: str, temp_dir: Path, expected_count: int, with_clicks: bool = False
+    input_md: str, temp_dir: Path, expected_count: int, with_clicks: bool = False,
+    dark: bool = False,
 ) -> list[Path]:
     """Export a Slidev deck to PNG images.
 
     Returns a sorted list of image paths. When *with_clicks* is True the
     ``--with-clicks`` flag is appended to the export command so that Slidev
     produces one image per click step (e.g. ``2.png``, ``2-1.png``, …).
+    When *dark* is True the ``--dark`` flag is appended so Slidev renders in
+    dark mode.
     """
     check_slidev_cli()
 
@@ -69,6 +72,9 @@ def render_slidev_slides(
 
     if with_clicks:
         cmd.append("--with-clicks")
+
+    if dark:
+        cmd.append("--dark")
 
     logger.debug("slidev command: %s", " ".join(cmd))
     print(f"  Running: {' '.join(cmd)}")

--- a/deck2video/tts.py
+++ b/deck2video/tts.py
@@ -68,6 +68,16 @@ def _play_audio(path: Path) -> None:
     subprocess.run(cmd, capture_output=True)
 
 
+def _label(item) -> str:
+    """Return a human-readable label for a Slide or Step."""
+    if hasattr(item, "slide_index"):
+        # Step object — include click context when past the initial state
+        if item.click > 0:
+            return f"Slide {item.slide_index} click {item.click}"
+        return f"Slide {item.slide_index}"
+    return f"Slide {item.index}"
+
+
 def _split_sentences(text: str) -> list[str]:
     """Split text into sentences, keeping punctuation attached."""
     parts = re.split(r'(?<=[.!?])\s+', text.strip())
@@ -184,7 +194,7 @@ def _generate_slide_audio(
         " ".join(sentences[i:i + 3])
         for i in range(0, len(sentences), 3)
     ]
-    logger.debug("Slide %d: %d sentence(s) in %d chunk(s)", slide.index, len(sentences), len(sentence_groups))
+    logger.debug("%s: %d sentence(s) in %d chunk(s)", _label(slide), len(sentences), len(sentence_groups))
 
     chunks: list = []
     try:
@@ -204,7 +214,7 @@ def _generate_slide_audio(
             del wav
             flush_fn()
             if len(sentence_groups) > 1:
-                print(f"  Slide {slide.index}: chunk {j + 1}/{len(sentence_groups)} OK")
+                print(f"  {_label(slide)}: chunk {j + 1}/{len(sentence_groups)} OK")
 
         combined = torch.cat(chunks, dim=1)
         del chunks
@@ -265,16 +275,16 @@ def generate_audio_for_slides(
         out_path = temp_dir / f"audio_{slide.index:03d}.wav"
 
         if slide.notes is None:
-            logger.debug("Slide %d: no notes, generating %ss silence", slide.index, hold_duration)
+            logger.debug("%s: no notes, generating %ss silence", _label(slide), hold_duration)
             generate_silent_wav(out_path, hold_duration)
-            print(f"  Slide {slide.index}: silent ({hold_duration}s)")
+            print(f"  {_label(slide)}: silent ({hold_duration}s)")
         else:
-            logger.debug("Slide %d: notes text=%r", slide.index, slide.notes)
+            logger.debug("%s: notes text=%r", _label(slide), slide.notes)
             if pronunciations:
                 original = slide.notes
                 slide.notes = apply_pronunciations(slide.notes, pronunciations)
                 if slide.notes != original:
-                    logger.debug("Slide %d: after pronunciations=%r", slide.index, slide.notes)
+                    logger.debug("%s: after pronunciations=%r", _label(slide), slide.notes)
 
             tts_kwargs = dict(
                 voice_path=voice_path,
@@ -291,7 +301,7 @@ def generate_audio_for_slides(
             except Exception as exc:
                 if on_gpu and _is_oom(exc):
                     # Fall back to CPU and retry this slide
-                    logger.warning("Slide %d: GPU OOM, retrying on CPU", slide.index)
+                    logger.warning("%s: GPU OOM, retrying on CPU", _label(slide))
                     _move_model_to_cpu(model)
                     on_gpu = False
                     try:
@@ -299,14 +309,14 @@ def generate_audio_for_slides(
                             model, slide, **tts_kwargs,
                         )
                     except Exception as retry_exc:
-                        msg = f"Slide {slide.index}: TTS failed on CPU ({retry_exc}), substituting silence"
+                        msg = f"{_label(slide)}: TTS failed on CPU ({retry_exc}), substituting silence"
                         logger.error(msg, exc_info=True)
                         print(f"  {msg}", file=sys.stderr)
                         generate_silent_wav(out_path, hold_duration)
                         audio_paths.append(out_path)
                         continue
                 else:
-                    msg = f"Slide {slide.index}: TTS failed ({exc}), substituting silence"
+                    msg = f"{_label(slide)}: TTS failed ({exc}), substituting silence"
                     logger.error(msg, exc_info=True)
                     print(f"  {msg}", file=sys.stderr)
                     generate_silent_wav(out_path, hold_duration)
@@ -316,14 +326,14 @@ def generate_audio_for_slides(
             torchaudio.save(str(out_path), combined, sr)
             del combined
             _flush_gpu()
-            print(f"  Slide {slide.index}: TTS OK ({n_sent} sentence{'s' if n_sent != 1 else ''} in {n_chunks} chunk{'s' if n_chunks != 1 else ''})")
+            print(f"  {_label(slide)}: TTS OK ({n_sent} sentence{'s' if n_sent != 1 else ''} in {n_chunks} chunk{'s' if n_chunks != 1 else ''})")
 
             if interactive:
                 _play_audio(out_path)
                 while True:
-                    choice = input("  (y) keep  (n) regenerate  (r) replay  (q) quit: ").strip().lower()
+                    choice = input(f"  {_label(slide)}: (y) keep  (n) regenerate  (r) replay  (q) quit: ").strip().lower()
                     if choice in ("", "y"):
-                        logger.debug("Slide %d: interactive — kept", slide.index)
+                        logger.debug("%s: interactive — kept", _label(slide))
                         break
                     if choice == "r":
                         _play_audio(out_path)
@@ -333,8 +343,8 @@ def generate_audio_for_slides(
                         print("  Quitting pipeline.")
                         sys.exit(0)
                     # choice == "n" or anything else: regenerate
-                    logger.debug("Slide %d: interactive — regenerating", slide.index)
-                    print(f"  Regenerating slide {slide.index}…")
+                    logger.debug("%s: interactive — regenerating", _label(slide))
+                    print(f"  Regenerating {_label(slide)}…")
                     try:
                         combined, sr, n_sent, n_chunks = _generate_slide_audio(
                             model, slide, **tts_kwargs,
@@ -345,7 +355,7 @@ def generate_audio_for_slides(
                     torchaudio.save(str(out_path), combined, sr)
                     del combined
                     _flush_gpu()
-                    print(f"  Slide {slide.index}: TTS OK ({n_sent} sentence{'s' if n_sent != 1 else ''} in {n_chunks} chunk{'s' if n_chunks != 1 else ''})")
+                    print(f"  {_label(slide)}: TTS OK ({n_sent} sentence{'s' if n_sent != 1 else ''} in {n_chunks} chunk{'s' if n_chunks != 1 else ''})")
                     _play_audio(out_path)
 
         audio_paths.append(out_path)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -35,6 +35,15 @@ Presentation format. Controls which parser and renderer are used.
 - **Details:** When set to `auto`, the format is [detected from the file content](format-detection.md). Set explicitly to skip detection or override a wrong guess.
 - **Example:** `--format slidev`
 
+### `--dark`
+
+Render Slidev slides in dark mode.
+
+- **Type:** flag (no argument)
+- **Default:** off
+- **Details:** Passes `--dark` to `slidev export`, producing images using Slidev's dark theme. Has no effect when rendering Marp presentations.
+- **Example:** `--dark`
+
 ### `--temp-dir`
 
 Directory for intermediate files (rendered PNGs, audio WAVs, video segments, log file).

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -180,7 +180,7 @@ Regenerate TTS audio for specific slides, then reassemble the full video.
 - **Default:** none
 - **Requires:** `--temp-dir` pointing to a directory from a previous run, plus the original input `.md` file
 - **Mutually exclusive with:** `--reassemble`
-- **Details:** Re-parses the markdown to get current speaker notes, regenerates audio for only the listed slides (overwriting the existing WAV files in place), then reassembles the full video. Slide numbers are 1-based and match the indices shown during a normal run. All TTS options (`--voice`, `--exaggeration`, etc.) apply to the regenerated slides.
+- **Details:** Re-parses the markdown to get current speaker notes, regenerates audio for only the listed slides (overwriting the existing WAV files in place), then reassembles the full video. Slide numbers are 1-based original slide numbers (not step indices). All TTS options (`--voice`, `--exaggeration`, etc.) apply to the regenerated slides. For Slidev decks with [click animations](writing-slides.md#slidev-click-animations), specifying a slide number regenerates **all** click steps for that slide (e.g., `--redo-slides 3` regenerates the initial state plus every click step of slide 3).
 - **Example:** `--redo-slides 2,5,7 --temp-dir ./build`
 
 ## Exit codes

--- a/docs/examples.md
+++ b/docs/examples.md
@@ -70,6 +70,69 @@ The `transition` key in frontmatter triggers Slidev auto-detection. Per-slide fr
 
 Note: since the video is a sequence of static PNGs, slide transitions from Slidev are not captured in the output.
 
+## Slidev click animations
+
+Use `[click]` markers in your speaker notes to sync narration with progressive reveal animations:
+
+**slides.md:**
+
+```markdown
+---
+transition: fade
+---
+
+# What We'll Cover
+
+<v-clicks>
+
+- Background and motivation
+- The core algorithm
+- Benchmarks and results
+
+</v-clicks>
+
+<!--
+Today I'll walk you through three topics.
+[click]
+First, some background on why this problem matters.
+[click]
+Then the core algorithm — the heart of the approach.
+[click]
+And finally, the benchmarks that show it actually works.
+-->
+
+---
+
+# Summary
+
+<!-- That covers everything. Questions welcome. -->
+```
+
+**Command:**
+
+```bash
+python -m deck2video slides.md --format slidev --voice voice.wav
+```
+
+**What happens:**
+
+deck2video detects the `[click]` markers and expands the first slide into four steps:
+
+```
+[1/4] Parsing slides…
+  Found 2 slides → 5 steps (click expansion)
+```
+
+The Slidev CLI is called with `--with-clicks`, producing `slides/1.png`, `slides/1-1.png`, `slides/1-2.png`, `slides/1-3.png`, and `slides/2.png`. Each gets its own narration segment and they're assembled into a single MP4 where the bullet points appear in sync with the spoken narration.
+
+**Redoing a click slide:**
+
+```bash
+# Regenerates all 4 steps of slide 1 (initial + 3 clicks)
+python -m deck2video slides.md --format slidev \
+    --redo-slides 1 --temp-dir ./build --voice voice.wav
+```
+
 ## Voice cloning with tuned parameters
 
 Record a 10-20 second WAV of yourself speaking naturally, then:

--- a/docs/interactive-mode.md
+++ b/docs/interactive-mode.md
@@ -14,14 +14,20 @@ python -m deck2video deck.md --voice voice.wav -i
 
 The pipeline runs normally through parsing and rendering. During TTS generation (step 3), after each slide's audio is synthesized, the audio plays automatically, you're prompted with keyboard controls, and the pipeline pauses until you respond.
 
-Slides without speaker notes (silent holds) are skipped.
+Slides without speaker notes (silent holds) are skipped. For Slidev decks with [click animations](writing-slides.md#slidev-click-animations), each click step is reviewed individually.
 
 ## Keyboard controls
 
-After each slide's audio plays, you see:
+After each slide's audio plays, you see a prompt that includes the slide label:
 
 ```
-  (y) keep  (n) regenerate  (r) replay  (q) quit:
+  Slide 3: (y) keep  (n) regenerate  (r) replay  (q) quit:
+```
+
+For Slidev click steps, the label includes click context:
+
+```
+  Slide 3 click 2: (y) keep  (n) regenerate  (r) replay  (q) quit:
 ```
 
 | Key | Action |
@@ -79,18 +85,29 @@ A typical interactive session:
   Using MPS (Apple Silicon) for TTS
   Slide 1: TTS OK (2 sentences in 1 chunk)
   (audio plays automatically)
-  (y) keep  (n) regenerate  (r) replay  (q) quit: y
+  Slide 1: (y) keep  (n) regenerate  (r) replay  (q) quit: y
   Slide 2: TTS OK (1 sentence in 1 chunk)
   (audio plays automatically)
-  (y) keep  (n) regenerate  (r) replay  (q) quit: n
-  Regenerating slide 2...
+  Slide 2: (y) keep  (n) regenerate  (r) replay  (q) quit: n
+  Regenerating Slide 2...
   Slide 2: TTS OK (1 sentence in 1 chunk)
   (new audio plays automatically)
-  (y) keep  (n) regenerate  (r) replay  (q) quit: y
+  Slide 2: (y) keep  (n) regenerate  (r) replay  (q) quit: y
   Slide 3: silent (3.0s)
   Slide 4: TTS OK (3 sentences in 1 chunk)
   (audio plays automatically)
-  (y) keep  (n) regenerate  (r) replay  (q) quit: y
+  Slide 4: (y) keep  (n) regenerate  (r) replay  (q) quit: y
+```
+
+For a Slidev deck with click animations, click steps appear individually:
+
+```
+  Slide 2: TTS OK (1 sentence in 1 chunk)
+  Slide 2: (y) keep  (n) regenerate  (r) replay  (q) quit: y
+  Slide 2 click 1: TTS OK (2 sentences in 1 chunk)
+  Slide 2 click 1: (y) keep  (n) regenerate  (r) replay  (q) quit: y
+  Slide 2 click 2: TTS OK (1 sentence in 1 chunk)
+  Slide 2 click 2: (y) keep  (n) regenerate  (r) replay  (q) quit: y
 ```
 
 ## Tips

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -61,17 +61,27 @@ On Windows, download from [ffmpeg.org](https://ffmpeg.org/download.html) and add
 Error: parsed 5 slides but marp-cli produced 3 images.
 ```
 
-This means the parser found a different number of slides than the renderer produced. Common causes:
+or, for Slidev with click animations:
 
-1. **Slidev per-slide frontmatter.** In Slidev, a slide with layout options uses a two-`---` block: `---\nlayout: section\n---`. The parser treats this as one separator. If you see a count mismatch where the parser finds more slides than Slidev exports, check for per-slide frontmatter blocks that aren't being collapsed correctly.
+```
+Error: expected 8 step(s) but slidev export produced 6 image(s).
+  Hint: verify that the number of [click] markers in your speaker notes
+  matches the v-click directives in each slide.
+```
 
-2. **Extra `---` delimiters.** A `---` inside a code block or at an unexpected position can create phantom slides during parsing. Check your markdown for stray horizontal rules.
+This means the parser (or step expansion) found a different number of steps than the renderer produced. Common causes:
 
-3. **Frontmatter issues.** If the frontmatter block isn't properly closed with `---`, the parser may miscount.
+1. **Click count mismatch (Slidev only).** The number of `[click]` markers in your speaker notes doesn't match the number of `v-click` / `<v-clicks>` steps in the slide body. Count the click steps in each slide and ensure the notes have the same number of `[click]` markers. See [Writing slides: click animations](writing-slides.md#slidev-click-animations).
 
-4. **Renderer behavior differences.** Marp-cli and Slidev may handle edge cases (empty slides, trailing delimiters) differently from the parser.
+2. **Slidev per-slide frontmatter.** In Slidev, a slide with layout options uses a two-`---` block: `---\nlayout: section\n---`. The parser treats this as one separator. If you see a count mismatch where the parser finds more slides than Slidev exports, check for per-slide frontmatter blocks that aren't being collapsed correctly.
 
-**Fix:** Inspect your markdown for stray `---` lines. Use `--keep-temp` to see the rendered images and compare with your expected slide count.
+3. **Extra `---` delimiters.** A `---` inside a code block or at an unexpected position can create phantom slides during parsing. Check your markdown for stray horizontal rules.
+
+4. **Frontmatter issues.** If the frontmatter block isn't properly closed with `---`, the parser may miscount.
+
+5. **Renderer behavior differences.** Marp-cli and Slidev may handle edge cases (empty slides, trailing delimiters) differently from the parser.
+
+**Fix:** Inspect your markdown for stray `---` lines. Use `--keep-temp` to see the rendered images and compare with your expected slide/step count.
 
 ## TTS quality issues
 
@@ -140,18 +150,20 @@ Error encountered. Temp files preserved at: /tmp/deck2video_abc123
 | `deck2video.log` | Detailed debug log of the entire pipeline run |
 | `slides.001` | Rendered PNG for slide 1 (Marp, no extension) |
 | `slides/1.png` | Rendered PNG for slide 1 (Slidev — exported to a subdirectory) |
-| `audio_001.wav` | TTS audio for slide 1 |
-| `audio_002.wav` | TTS audio for slide 2 (or silence) |
-| `segment_001.ts` | Encoded MPEG-TS video segment for slide 1 |
-| `segment_002.ts` | Encoded MPEG-TS video segment for slide 2 |
+| `slides/2-1.png` | Rendered PNG for slide 2, after click 1 (Slidev with `[click]` markers) |
+| `audio_001.wav` | TTS audio for step 1 |
+| `audio_002.wav` | TTS audio for step 2 (or silence) |
+| `segment_001.ts` | Encoded MPEG-TS video segment for step 1 |
+| `segment_002.ts` | Encoded MPEG-TS video segment for step 2 |
 | `concat.txt` | ffmpeg concat demuxer input listing all segments |
 
 ### File naming conventions
 
 - All indices are zero-padded to 3 digits: `001`, `002`, ..., `999`.
-- Slide numbering starts at 1 (matching the slide index in output messages).
+- Step numbering starts at 1 (matching the step index in output messages). For decks without click animations, step = slide.
 - Audio files: `audio_{index}.wav`
 - Image files: `slides.{index}` (Marp) or `slides/{index}.png` (Slidev — in a subdirectory, not zero-padded)
+- Slidev click step images: `slides/{slide}-{click}.png` (e.g. `slides/3-2.png` = slide 3, after click 2)
 - Segments: `segment_{index}.ts`
 
 ### Inspecting the log file

--- a/docs/writing-slides.md
+++ b/docs/writing-slides.md
@@ -177,7 +177,68 @@ This appears on click.
 
 deck2video does not process these components; they're passed through to the Slidev CLI for rendering. The presence of Vue components (`v-click`, `v-clicks`, `v-after`, `v-click-hide`, `Arrow`, `RenderWhen`, `SlidevVideo`) is used as a signal for [auto-detection](format-detection.md).
 
-Note: since deck2video exports static PNGs, click animations in the final video will show the slide in its final state (all elements visible). If you need step-by-step reveals, consider splitting them into separate slides.
+## Slidev click animations
+
+When you use `v-click` or `v-clicks` for progressive reveal, you can sync narration to each animation step by adding `[click]` markers in your speaker notes. deck2video treats each marker as a step boundary: the text before the marker plays while the slide is in its initial state, the text after plays when the first animation fires, and so on.
+
+### Writing click markers
+
+Place `[click]` on its own line inside an HTML comment, at each point in the narration where the next animation should have already triggered:
+
+```markdown
+---
+
+# Key Features
+
+<v-clicks>
+
+- Fast — sub-millisecond latency
+- Reliable — 99.99% uptime SLA
+- Scalable — handles millions of requests
+
+</v-clicks>
+
+<!--
+Let's look at the three key features of our platform.
+[click]
+First, it's fast — with sub-millisecond latency at the 99th percentile.
+[click]
+Second, it's reliable — we maintain a 99.99% uptime SLA.
+[click]
+And third, it scales to handle millions of requests without configuration.
+-->
+```
+
+This produces four video segments for the slide:
+- **Initial state** (no bullets visible): "Let's look at the three key features of our platform."
+- **After click 1** (first bullet visible): "First, it's fast..."
+- **After click 2** (two bullets visible): "Second, it's reliable..."
+- **After click 3** (all bullets visible): "And third, it scales..."
+
+### Rules
+
+- `[click]` must appear on its own line (leading/trailing whitespace is ignored).
+- Matching is case-insensitive (`[CLICK]` and `[Click]` both work).
+- A fragment with only whitespace between two markers produces a silent hold for that step.
+- The number of `[click]` markers in your notes must match the number of `v-click` steps in the slide. If they don't match, Slidev will export a different number of images than expected and the pipeline will exit with an error.
+- `[click]` markers in video-directive slides (`<!-- video: ... -->`) are stripped and the slide is never click-expanded.
+- Marp slides are unaffected — click expansion only applies to Slidev.
+
+### Click count mismatch
+
+If you write three `[click]` markers but a slide has five `v-click` directives, the Slidev CLI exports five images but deck2video expects four. The pipeline exits with:
+
+```
+Error: expected 4 step(s) but slidev export produced 6 image(s).
+  Hint: verify that the number of [click] markers in your speaker notes
+  matches the v-click directives in each slide.
+```
+
+Count the `v-click` / `<v-clicks>` entries in the slide body and ensure you have the same number of `[click]` markers in the notes. Each item in a `<v-clicks>` list counts as one click.
+
+### Slides with v-click but no [click] markers
+
+If a slide has `v-click` directives but you haven't added `[click]` markers to the notes, deck2video treats it as a single step. The Slidev CLI will export multiple images (initial state + one per click) but deck2video will expect only one — causing the same count mismatch error above. Add `[click]` markers to your notes, or remove the `v-click` directives if you don't need step-by-step reveal in the video.
 
 ## Video directive
 

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -430,3 +430,29 @@ class TestAssembleVideo:
             cmd = c[0][0]
             af_idx = cmd.index("-af")
             assert "adelay=250|250" in cmd[af_idx + 1]
+
+    @patch("deck2video.assembler.get_audio_duration", return_value=3.0)
+    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    def test_per_step_padding_list(self, mock_run, mock_dur, tmp_path):
+        """Per-step padding list applies a different value to each segment."""
+        images, audios = self._make_files(tmp_path, 3)
+        output = tmp_path / "out.mp4"
+        output.touch()
+
+        assemble_video(images, audios, output, temp_dir=tmp_path, fps=24,
+                       audio_padding_ms=[500, 0, 500])
+
+        calls = mock_run.call_args_list[:-1]  # exclude concat
+        # Segment 1: padding=500 → adelay present
+        cmd0 = calls[0][0][0]
+        af0 = cmd0.index("-af")
+        assert "adelay=500|500" in cmd0[af0 + 1]
+
+        # Segment 2: padding=0 → no adelay
+        cmd1 = calls[1][0][0]
+        assert "-af" not in cmd1
+
+        # Segment 3: padding=500 → adelay present
+        cmd2 = calls[2][0][0]
+        af2 = cmd2.index("-af")
+        assert "adelay=500|500" in cmd2[af2 + 1]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -424,6 +424,60 @@ class TestFormatRouting:
         mocks["deck2video.__main__.parse_slidev"].assert_called_once()
         mocks["deck2video.__main__.render_slidev_slides"].assert_called_once()
 
+    def test_slidev_with_clicks_expands_steps(self, tmp_path):
+        """Slidev slides with [click] markers expand into steps; renderer gets step count."""
+        from deck2video.models import Slide
+
+        md = tmp_path / "deck.md"
+        md.write_text("---\ntransition: fade\n---\n\n# Slide\n")
+
+        # Two slides, first has 1 click (→ 2 steps), second has none (→ 1 step) = 3 total
+        slides_with_clicks = [
+            Slide(index=1, body="body", notes="First.\n[click]\nSecond.", video=None),
+            Slide(index=2, body="body", notes="Third.", video=None),
+        ]
+        patches = _patch_pipeline(**{
+            "deck2video.__main__.parse_slidev": MagicMock(return_value=slides_with_clicks),
+            "deck2video.__main__.render_slidev_slides": MagicMock(return_value=[
+                Path("/tmp/1.png"), Path("/tmp/2.png"), Path("/tmp/2-1.png"),
+            ]),
+            "deck2video.__main__.generate_audio_for_slides": MagicMock(return_value=[
+                Path("/tmp/audio_001.wav"), Path("/tmp/audio_002.wav"), Path("/tmp/audio_003.wav"),
+            ]),
+        })
+        mocks = self._run_main(["deck2video", str(md), "--format", "slidev"], patches)
+
+        # Renderer should be called with expected_count=3 and with_clicks=True
+        render_call = mocks["deck2video.__main__.render_slidev_slides"]
+        render_kwargs = render_call.call_args[1]
+        assert render_kwargs["expected_count"] == 3
+        assert render_kwargs["with_clicks"] is True
+
+        # TTS should receive 3 steps
+        gen_call = mocks["deck2video.__main__.generate_audio_for_slides"]
+        steps_arg = gen_call.call_args[0][0]
+        assert len(steps_arg) == 3
+
+    def test_slidev_without_clicks_no_with_clicks_flag(self, tmp_path):
+        """Slidev slides without [click] markers should not pass with_clicks=True."""
+        from deck2video.models import Slide
+
+        md = tmp_path / "deck.md"
+        md.write_text("---\ntransition: fade\n---\n\n# Slide\n")
+
+        slides_no_clicks = [
+            Slide(index=1, body="body", notes="Hello.", video=None),
+            Slide(index=2, body="body", notes=None, video=None),
+        ]
+        patches = _patch_pipeline(**{
+            "deck2video.__main__.parse_slidev": MagicMock(return_value=slides_no_clicks),
+        })
+        mocks = self._run_main(["deck2video", str(md), "--format", "slidev"], patches)
+
+        render_call = mocks["deck2video.__main__.render_slidev_slides"]
+        render_kwargs = render_call.call_args[1]
+        assert render_kwargs.get("with_clicks") is False
+
 
 # ---------------------------------------------------------------------------
 # Pipeline failure and --keep-temp
@@ -540,6 +594,34 @@ class TestDiscoverTempFiles:
         (tmp_path / "audio_001.wav").touch()
         with pytest.raises(SystemExit):
             _discover_temp_files(tmp_path)
+
+    def test_finds_click_step_images_in_slides_subdir(self, tmp_path):
+        """Click-step images like 2-1.png in slides/ subdir should be discovered."""
+        slides_dir = tmp_path / "slides"
+        slides_dir.mkdir()
+        for name in ["1.png", "2.png", "2-1.png"]:
+            (slides_dir / name).touch()
+        for i in range(1, 4):
+            (tmp_path / f"audio_{i:03d}.wav").touch()
+
+        images, audio = _discover_temp_files(tmp_path)
+        assert len(images) == 3
+        names = [p.name for p in images]
+        assert names == ["1.png", "2.png", "2-1.png"]
+
+    def test_click_step_images_sorted_correctly(self, tmp_path):
+        """Click steps must interleave between slides, not sort lexicographically."""
+        slides_dir = tmp_path / "slides"
+        slides_dir.mkdir()
+        # Out-of-order creation to test sort
+        for name in ["3.png", "2-2.png", "1.png", "2.png", "2-1.png"]:
+            (slides_dir / name).touch()
+        for i in range(1, 6):
+            (tmp_path / f"audio_{i:03d}.wav").touch()
+
+        images, _ = _discover_temp_files(tmp_path)
+        names = [p.name for p in images]
+        assert names == ["1.png", "2.png", "2-1.png", "2-2.png", "3.png"]
 
 
 # ---------------------------------------------------------------------------
@@ -836,3 +918,43 @@ class TestRedoSlidesMode:
                                  "--redo-slides", "1", "--temp-dir", str(tmp_path)]):
             with pytest.raises(SystemExit):
                 main()
+
+    def test_redo_slides_slidev_with_clicks_regenerates_all_steps_for_slide(self, tmp_path):
+        """--redo-slides on a Slidev deck regenerates all steps for the specified slide."""
+        md = tmp_path / "deck.md"
+        md.write_text("---\ntransition: fade\n---\n\n# Slide 1\n\n---\n\n# Slide 2\n")
+        temp = tmp_path / "build"
+        temp.mkdir()
+        # 4 steps total: slide 1 → 2 steps, slide 2 → 2 steps
+        for i in range(1, 5):
+            (temp / f"audio_{i:03d}.wav").touch()
+        slides_subdir = temp / "slides"
+        slides_subdir.mkdir()
+        for name in ["1.png", "1-1.png", "2.png", "2-1.png"]:
+            (slides_subdir / name).touch()
+
+        slides = [
+            Slide(index=1, body="# Slide 1", notes="A.\n[click]\nB.", video=None),
+            Slide(index=2, body="# Slide 2", notes="C.\n[click]\nD.", video=None),
+        ]
+        patches = _patch_pipeline(**{
+            "deck2video.__main__.detect_format": MagicMock(return_value="slidev"),
+            "deck2video.__main__.parse_slidev": MagicMock(return_value=slides),
+            "deck2video.__main__.generate_audio_for_slides": MagicMock(return_value=[
+                Path(str(temp / "audio_001.wav")),
+                Path(str(temp / "audio_002.wav")),
+            ]),
+        })
+
+        mocks = self._run_main(
+            ["deck2video", str(md), "--redo-slides", "1",
+             "--temp-dir", str(temp), "--format", "slidev"],
+            patches,
+        )
+
+        gen_call = mocks["deck2video.__main__.generate_audio_for_slides"]
+        gen_call.assert_called_once()
+        steps_arg = gen_call.call_args[0][0]
+        # Should regenerate both steps for slide 1 (slide_index==1)
+        assert len(steps_arg) == 2
+        assert all(s.slide_index == 1 for s in steps_arg)

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -9,8 +9,8 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from deck2video.__main__ import _discover_temp_files, _parse_slide_list, _resolve_videos_and_fps
-from deck2video.models import Slide
+from deck2video.__main__ import _build_padding_list, _discover_temp_files, _parse_slide_list, _resolve_videos_and_fps
+from deck2video.models import Slide, Step
 
 
 # ---------------------------------------------------------------------------
@@ -293,6 +293,47 @@ class TestFpsAutoDetection:
 # Audio padding
 # ---------------------------------------------------------------------------
 
+class TestBuildPaddingList:
+    """Unit tests for _build_padding_list."""
+
+    def _slide(self, index):
+        return Slide(index=index, body="", notes=None)
+
+    def _step(self, index, slide_index, click):
+        return Step(index=index, slide_index=slide_index, click=click, notes=None)
+
+    def test_all_slides_use_audio_padding(self):
+        slides = [self._slide(1), self._slide(2), self._slide(3)]
+        result = _build_padding_list(slides, audio_padding_ms=500, with_clicks_padding_ms=0)
+        assert result == [500, 500, 500]
+
+    def test_click_steps_use_with_clicks_padding(self):
+        steps = [
+            self._step(1, 1, 0),   # slide boundary
+            self._step(2, 1, 1),   # click step
+            self._step(3, 2, 0),   # slide boundary
+            self._step(4, 2, 1),   # click step
+        ]
+        result = _build_padding_list(steps, audio_padding_ms=500, with_clicks_padding_ms=100)
+        assert result == [500, 100, 500, 100]
+
+    def test_no_clicks_same_as_scalar(self):
+        steps = [self._step(1, 1, 0), self._step(2, 2, 0)]
+        result = _build_padding_list(steps, audio_padding_ms=300, with_clicks_padding_ms=50)
+        assert result == [300, 300]
+
+    def test_with_clicks_padding_zero_by_default_effect(self):
+        steps = [self._step(1, 1, 0), self._step(2, 1, 1), self._step(3, 2, 0)]
+        result = _build_padding_list(steps, audio_padding_ms=400, with_clicks_padding_ms=0)
+        assert result == [400, 0, 400]
+
+    def test_marp_slides_no_click_attribute(self):
+        slides = [self._slide(1), self._slide(2)]
+        result = _build_padding_list(slides, audio_padding_ms=200, with_clicks_padding_ms=999)
+        # Slide objects have no click attribute → always audio_padding_ms
+        assert result == [200, 200]
+
+
 class TestAudioPadding:
     def _run_main(self, argv, patches):
         import contextlib
@@ -312,7 +353,8 @@ class TestAudioPadding:
 
         mocks = self._run_main(["deck2video", str(md)], _patch_pipeline())
         assemble_call = mocks["deck2video.__main__.assemble_video"]
-        assert assemble_call.call_args[1]["audio_padding_ms"] == 0
+        # Marp: 2 slides, both click=0, default padding 0 → [0, 0]
+        assert assemble_call.call_args[1]["audio_padding_ms"] == [0, 0]
 
     def test_padding_passed_to_assembler(self, tmp_path):
         md = tmp_path / "deck.md"
@@ -323,7 +365,38 @@ class TestAudioPadding:
             _patch_pipeline(),
         )
         assemble_call = mocks["deck2video.__main__.assemble_video"]
-        assert assemble_call.call_args[1]["audio_padding_ms"] == 400
+        # Marp: 2 slides → [400, 400]
+        assert assemble_call.call_args[1]["audio_padding_ms"] == [400, 400]
+
+    def test_with_clicks_padding_applies_to_click_steps(self, tmp_path):
+        """Click steps use --with-clicks-audio-padding; slide boundaries use --audio-padding."""
+        md = tmp_path / "deck.md"
+        md.write_text("---\ntransition: fade\n---\n\n# Slide\n")
+
+        slides = [
+            Slide(index=1, body="# Slide 1", notes="A.\n[click]\nB.", video=None),
+            Slide(index=2, body="# Slide 2", notes="C.", video=None),
+        ]
+        patches = _patch_pipeline(**{
+            "deck2video.__main__.detect_format": MagicMock(return_value="slidev"),
+            "deck2video.__main__.parse_slidev": MagicMock(return_value=slides),
+            "deck2video.__main__.render_slidev_slides": MagicMock(return_value=[
+                Path("/tmp/1.png"), Path("/tmp/1-1.png"), Path("/tmp/2.png"),
+            ]),
+            "deck2video.__main__.generate_audio_for_slides": MagicMock(return_value=[
+                Path("/tmp/audio_001.wav"),
+                Path("/tmp/audio_002.wav"),
+                Path("/tmp/audio_003.wav"),
+            ]),
+        })
+        mocks = self._run_main(
+            ["deck2video", str(md), "--format", "slidev",
+             "--audio-padding", "500", "--with-clicks-audio-padding", "100"],
+            patches,
+        )
+        assemble_call = mocks["deck2video.__main__.assemble_video"]
+        # steps: slide1/click0=500, slide1/click1=100, slide2/click0=500
+        assert assemble_call.call_args[1]["audio_padding_ms"] == [500, 100, 500]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1031,3 +1031,327 @@ class TestRedoSlidesMode:
         # Should regenerate both steps for slide 1 (slide_index==1)
         assert len(steps_arg) == 2
         assert all(s.slide_index == 1 for s in steps_arg)
+
+
+# ---------------------------------------------------------------------------
+# Manifest helpers: _write_manifest, _read_manifest
+# ---------------------------------------------------------------------------
+
+class TestManifestHelpers:
+    def test_round_trip(self, tmp_path):
+        from deck2video.__main__ import _read_manifest, _write_manifest
+        from deck2video.models import Step
+
+        steps = [
+            Step(index=1, slide_index=1, click=0, notes="Hello"),
+            Step(index=2, slide_index=2, click=0, notes=None),
+            Step(index=3, slide_index=2, click=1, notes="World"),
+        ]
+        _write_manifest(steps, tmp_path)
+
+        manifest = _read_manifest(tmp_path)
+        assert manifest is not None
+        assert len(manifest) == 3
+        assert manifest[0] == {"index": 1, "slide_index": 1, "click": 0}
+        assert manifest[2] == {"index": 3, "slide_index": 2, "click": 1}
+
+    def test_read_missing_returns_none(self, tmp_path):
+        from deck2video.__main__ import _read_manifest
+        assert _read_manifest(tmp_path) is None
+
+    def test_write_creates_steps_json(self, tmp_path):
+        from deck2video.__main__ import _write_manifest
+        from deck2video.models import Step
+
+        steps = [Step(index=1, slide_index=1, click=0, notes=None)]
+        _write_manifest(steps, tmp_path)
+        assert (tmp_path / "steps.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# _build_audio_remap helper
+# ---------------------------------------------------------------------------
+
+class TestBuildAudioRemap:
+    def test_no_change_returns_empty_map(self):
+        from deck2video.__main__ import _build_audio_remap
+        from deck2video.models import Step
+
+        old_steps = [
+            {"index": 1, "slide_index": 1, "click": 0},
+            {"index": 2, "slide_index": 2, "click": 0},
+            {"index": 3, "slide_index": 3, "click": 0},
+        ]
+        new_steps = [
+            Step(index=1, slide_index=1, click=0, notes=None),
+            Step(index=2, slide_index=2, click=0, notes=None),
+            Step(index=3, slide_index=3, click=0, notes=None),
+        ]
+        rename_map = _build_audio_remap(old_steps, new_steps, redo_slide_indices={2})
+        # Slide 2 is redo'd; slides 1 and 3 are unchanged and at same positions
+        assert rename_map == {}
+
+    def test_click_added_shifts_later_slides(self):
+        """Slide 2 gains a click (1→2 steps). Slide 3 shifts from index 3 to 4."""
+        from deck2video.__main__ import _build_audio_remap
+        from deck2video.models import Step
+
+        old_steps = [
+            {"index": 1, "slide_index": 1, "click": 0},
+            {"index": 2, "slide_index": 2, "click": 0},
+            {"index": 3, "slide_index": 3, "click": 0},
+        ]
+        new_steps = [
+            Step(index=1, slide_index=1, click=0, notes=None),
+            Step(index=2, slide_index=2, click=0, notes=None),  # redo'd
+            Step(index=3, slide_index=2, click=1, notes=None),  # redo'd (new step)
+            Step(index=4, slide_index=3, click=0, notes=None),  # shifted 3→4
+        ]
+        rename_map = _build_audio_remap(old_steps, new_steps, redo_slide_indices={2})
+        assert rename_map == {3: 4}
+
+    def test_click_removed_shifts_later_slides(self):
+        """Slide 2 loses a click (2→1 steps). Slide 3 shifts from index 4 to 3."""
+        from deck2video.__main__ import _build_audio_remap
+        from deck2video.models import Step
+
+        old_steps = [
+            {"index": 1, "slide_index": 1, "click": 0},
+            {"index": 2, "slide_index": 2, "click": 0},
+            {"index": 3, "slide_index": 2, "click": 1},
+            {"index": 4, "slide_index": 3, "click": 0},
+        ]
+        new_steps = [
+            Step(index=1, slide_index=1, click=0, notes=None),
+            Step(index=2, slide_index=2, click=0, notes=None),  # redo'd
+            Step(index=3, slide_index=3, click=0, notes=None),  # shifted 4→3
+        ]
+        rename_map = _build_audio_remap(old_steps, new_steps, redo_slide_indices={2})
+        assert rename_map == {4: 3}
+
+    def test_no_clicks_to_one_click(self):
+        """Slide 2 gains its first click (1→2 steps). Slides 3+ shift by 1."""
+        from deck2video.__main__ import _build_audio_remap
+        from deck2video.models import Step
+
+        old_steps = [
+            {"index": 1, "slide_index": 1, "click": 0},
+            {"index": 2, "slide_index": 2, "click": 0},
+            {"index": 3, "slide_index": 3, "click": 0},
+            {"index": 4, "slide_index": 4, "click": 0},
+        ]
+        new_steps = [
+            Step(index=1, slide_index=1, click=0, notes=None),
+            Step(index=2, slide_index=2, click=0, notes=None),  # redo'd
+            Step(index=3, slide_index=2, click=1, notes=None),  # redo'd (new)
+            Step(index=4, slide_index=3, click=0, notes=None),  # 3→4
+            Step(index=5, slide_index=4, click=0, notes=None),  # 4→5
+        ]
+        rename_map = _build_audio_remap(old_steps, new_steps, redo_slide_indices={2})
+        assert rename_map == {3: 4, 4: 5}
+
+
+# ---------------------------------------------------------------------------
+# _apply_audio_renames helper
+# ---------------------------------------------------------------------------
+
+class TestApplyAudioRenames:
+    def test_renames_shifted_files(self, tmp_path):
+        from deck2video.__main__ import _apply_audio_renames
+
+        # Create old audio files: slide3 was at index 3, now moves to 4
+        (tmp_path / "audio_001.wav").write_text("s1")
+        (tmp_path / "audio_003.wav").write_text("s3")
+
+        old_steps = [
+            {"index": 1, "slide_index": 1, "click": 0},
+            {"index": 2, "slide_index": 2, "click": 0},  # redo'd
+            {"index": 3, "slide_index": 3, "click": 0},
+        ]
+        rename_map = {3: 4}
+        _apply_audio_renames(rename_map, old_steps, redo_slide_indices={2}, temp_dir=tmp_path)
+
+        assert (tmp_path / "audio_001.wav").exists()   # unchanged
+        assert (tmp_path / "audio_004.wav").exists()   # renamed from 3
+        assert not (tmp_path / "audio_003.wav").exists()  # gone (became 4)
+
+    def test_deletes_redo_files(self, tmp_path):
+        from deck2video.__main__ import _apply_audio_renames
+
+        (tmp_path / "audio_002.wav").write_text("s2c0")
+        (tmp_path / "audio_003.wav").write_text("s2c1")
+
+        old_steps = [
+            {"index": 1, "slide_index": 1, "click": 0},
+            {"index": 2, "slide_index": 2, "click": 0},
+            {"index": 3, "slide_index": 2, "click": 1},
+        ]
+        _apply_audio_renames({}, old_steps, redo_slide_indices={2}, temp_dir=tmp_path)
+
+        assert not (tmp_path / "audio_002.wav").exists()
+        assert not (tmp_path / "audio_003.wav").exists()
+
+    def test_staging_avoids_collision(self, tmp_path):
+        """A→B and B→C chain must not clobber B before it's moved to C."""
+        from deck2video.__main__ import _apply_audio_renames
+
+        # Scenario: Slide 1 gains an extra click (1 click → 2 clicks).
+        # Old: s1c0@1, s1c1@2, s2@3, s3@4  (redo slide 1)
+        # New: s1c0@1, s1c1@2, s1c2@3, s2@4, s3@5
+        # rename_map: {3: 4, 4: 5}  — without staging, renaming 3→4 clobbers s3.
+        (tmp_path / "audio_003.wav").write_text("slide2")
+        (tmp_path / "audio_004.wav").write_text("slide3")
+
+        old_steps = [
+            {"index": 1, "slide_index": 1, "click": 0},
+            {"index": 2, "slide_index": 1, "click": 1},
+            {"index": 3, "slide_index": 2, "click": 0},
+            {"index": 4, "slide_index": 3, "click": 0},
+        ]
+        rename_map = {3: 4, 4: 5}
+        _apply_audio_renames(rename_map, old_steps, redo_slide_indices={1}, temp_dir=tmp_path)
+
+        # Old slide 2 data must arrive at position 4
+        assert (tmp_path / "audio_004.wav").read_text() == "slide2"
+        # Old slide 3 data must arrive at position 5 (not lost to the 3→4 rename)
+        assert (tmp_path / "audio_005.wav").read_text() == "slide3"
+        # Positions 1 and 2 belonged to redo'd slide 1 (didn't exist, so just absent)
+        assert not (tmp_path / "audio_003.wav").exists()
+
+
+# ---------------------------------------------------------------------------
+# --redo-slides with click-count change (integration-style)
+# ---------------------------------------------------------------------------
+
+class TestRedoSlidesClickChange:
+    def _run_main(self, argv, patches):
+        import contextlib
+        from deck2video.__main__ import main
+
+        with patch("sys.argv", argv):
+            with contextlib.ExitStack() as stack:
+                mocks = {}
+                for target, mock_obj in patches.items():
+                    mocks[target] = stack.enter_context(patch(target, mock_obj))
+                main()
+                return mocks
+
+    def test_click_added_rerenders_and_remaps(self, tmp_path):
+        """When slide 2 gains a click, images are re-rendered and audio remapped."""
+        md = tmp_path / "deck.md"
+        md.write_text("---\ntransition: fade\n---\n\n# Slide 1\n\n---\n\n# Slide 2\n\n---\n\n# Slide 3\n")
+        temp = tmp_path / "build"
+        temp.mkdir()
+
+        # Old structure: 3 slides, no clicks → 3 audio files
+        for i in range(1, 4):
+            (temp / f"audio_{i:03d}.wav").write_text(f"old{i}")
+        slides_dir = temp / "slides"
+        slides_dir.mkdir()
+        for i in range(1, 4):
+            (slides_dir / f"{i}.png").touch()
+
+        # Write manifest reflecting the old structure (no clicks)
+        old_manifest = [
+            {"index": 1, "slide_index": 1, "click": 0},
+            {"index": 2, "slide_index": 2, "click": 0},
+            {"index": 3, "slide_index": 3, "click": 0},
+        ]
+        import json as _json
+        (temp / "steps.json").write_text(_json.dumps(old_manifest))
+
+        # New slide 2 has a click → 4 steps total
+        new_slides = [
+            Slide(index=1, body="# 1", notes="A.", video=None),
+            Slide(index=2, body="# 2", notes="B.\n[click]\nC.", video=None),
+            Slide(index=3, body="# 3", notes="D.", video=None),
+        ]
+
+        # render mock creates the new image files
+        def fake_render(*args, **kw):
+            new_slides_dir = temp / "slides"
+            new_slides_dir.mkdir(exist_ok=True)
+            new_images = [
+                new_slides_dir / "1.png",
+                new_slides_dir / "2.png",
+                new_slides_dir / "2-1.png",
+                new_slides_dir / "3.png",
+            ]
+            for p in new_images:
+                p.touch()
+            return new_images
+
+        # TTS mock writes the audio files for redo'd steps
+        def fake_generate(steps, **kw):
+            paths = []
+            for s in steps:
+                p = temp / f"audio_{s.index:03d}.wav"
+                p.write_text(f"new{s.index}")
+                paths.append(p)
+            return paths
+
+        patches = _patch_pipeline(**{
+            "deck2video.__main__.detect_format": MagicMock(return_value="slidev"),
+            "deck2video.__main__.parse_slidev": MagicMock(return_value=new_slides),
+            "deck2video.__main__.render_slidev_slides": MagicMock(side_effect=fake_render),
+            "deck2video.__main__.generate_audio_for_slides": MagicMock(side_effect=fake_generate),
+        })
+
+        mocks = self._run_main(
+            ["deck2video", str(md), "--redo-slides", "2",
+             "--temp-dir", str(temp), "--format", "slidev"],
+            patches,
+        )
+
+        # render_slidev_slides MUST have been called (click change requires re-render)
+        mocks["deck2video.__main__.render_slidev_slides"].assert_called_once()
+
+        # TTS called only for slide 2's steps (2 of them)
+        gen_call = mocks["deck2video.__main__.generate_audio_for_slides"]
+        gen_call.assert_called_once()
+        redo_steps = gen_call.call_args[0][0]
+        assert len(redo_steps) == 2
+        assert all(s.slide_index == 2 for s in redo_steps)
+
+        # audio_004.wav should hold old slide 3 data (renamed from position 3 → 4)
+        assert (temp / "audio_004.wav").read_text() == "old3"
+
+        # Manifest should be updated to reflect 4 steps
+        updated = _json.loads((temp / "steps.json").read_text())
+        assert len(updated) == 4
+
+    def test_no_manifest_falls_through_to_existing_path(self, tmp_path):
+        """If steps.json is absent, redo proceeds without click-change detection."""
+        md = tmp_path / "deck.md"
+        md.write_text("---\ntransition: fade\n---\n\n# Slide 1\n\n---\n\n# Slide 2\n")
+        temp = tmp_path / "build"
+        temp.mkdir()
+        for i in range(1, 3):
+            (temp / f"slides.{i:03d}.png").touch()
+            (temp / f"audio_{i:03d}.wav").touch()
+
+        slides = [
+            Slide(index=1, body="# 1", notes="Hello.", video=None),
+            Slide(index=2, body="# 2", notes="World.", video=None),
+        ]
+        patches = _patch_pipeline(**{
+            "deck2video.__main__.detect_format": MagicMock(return_value="slidev"),
+            "deck2video.__main__.parse_slidev": MagicMock(return_value=slides),
+            "deck2video.__main__.generate_audio_for_slides": MagicMock(return_value=[
+                temp / "audio_001.wav", temp / "audio_002.wav",
+            ]),
+        })
+
+        mocks = self._run_main(
+            ["deck2video", str(md), "--redo-slides", "2",
+             "--temp-dir", str(temp), "--format", "slidev"],
+            patches,
+        )
+
+        # render_slidev_slides should NOT be called (no click change detected)
+        mocks["deck2video.__main__.render_slidev_slides"].assert_not_called()
+        mocks["deck2video.__main__.assemble_video"].assert_called_once()
+
+        # Manifest should now exist (written by redo path)
+        assert (temp / "steps.json").exists()
+

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,179 @@
+"""Tests for deck2video.models — Step dataclass, click splitting, and expansion."""
+
+from __future__ import annotations
+
+import pytest
+
+from deck2video.models import (
+    CLICK_RE,
+    Slide,
+    Step,
+    expand_slides_to_steps,
+    split_notes_on_clicks,
+)
+
+
+# ---------------------------------------------------------------------------
+# split_notes_on_clicks
+# ---------------------------------------------------------------------------
+
+class TestSplitNotesOnClicks:
+    def test_no_markers_returns_single_element(self):
+        result = split_notes_on_clicks("Hello world.")
+        assert result == ["Hello world."]
+
+    def test_none_returns_none_list(self):
+        result = split_notes_on_clicks(None)
+        assert result == [None]
+
+    def test_one_marker_splits_into_two(self):
+        result = split_notes_on_clicks("First part.\n[click]\nSecond part.")
+        assert result == ["First part.", "Second part."]
+
+    def test_multiple_markers(self):
+        result = split_notes_on_clicks("A.\n[click]\nB.\n[click]\nC.")
+        assert result == ["A.", "B.", "C."]
+
+    def test_whitespace_only_fragment_becomes_none(self):
+        result = split_notes_on_clicks("[click]\nSome text.")
+        assert result == [None, "Some text."]
+
+    def test_trailing_click_produces_none(self):
+        result = split_notes_on_clicks("Some text.\n[click]")
+        assert result == ["Some text.", None]
+
+    def test_case_insensitive(self):
+        result = split_notes_on_clicks("A.\n[CLICK]\nB.")
+        assert result == ["A.", "B."]
+
+    def test_mixed_case(self):
+        result = split_notes_on_clicks("A.\n[Click]\nB.")
+        assert result == ["A.", "B."]
+
+    def test_surrounding_whitespace_stripped(self):
+        result = split_notes_on_clicks("  Hello.  \n[click]\n  World.  ")
+        assert result == ["Hello.", "World."]
+
+    def test_empty_string_returns_none_list(self):
+        result = split_notes_on_clicks("")
+        assert result == [None]
+
+    def test_click_with_spaces_on_line(self):
+        result = split_notes_on_clicks("A.\n  [click]  \nB.")
+        assert result == ["A.", "B."]
+
+
+# ---------------------------------------------------------------------------
+# Step dataclass
+# ---------------------------------------------------------------------------
+
+class TestStepDataclass:
+    def test_field_access(self):
+        step = Step(index=3, slide_index=2, click=1, notes="Hello.")
+        assert step.index == 3
+        assert step.slide_index == 2
+        assert step.click == 1
+        assert step.notes == "Hello."
+        assert step.video is None
+
+    def test_video_default_is_none(self):
+        step = Step(index=1, slide_index=1, click=0, notes=None)
+        assert step.video is None
+
+    def test_video_can_be_set(self):
+        step = Step(index=1, slide_index=1, click=0, notes=None, video="demo.mov")
+        assert step.video == "demo.mov"
+
+
+# ---------------------------------------------------------------------------
+# expand_slides_to_steps
+# ---------------------------------------------------------------------------
+
+class TestExpandSlidesToSteps:
+    def test_slide_without_clicks_becomes_one_step(self):
+        slides = [Slide(index=1, body="# Slide", notes="Hello.")]
+        steps = expand_slides_to_steps(slides)
+        assert len(steps) == 1
+        assert steps[0].index == 1
+        assert steps[0].slide_index == 1
+        assert steps[0].click == 0
+        assert steps[0].notes == "Hello."
+
+    def test_slide_with_one_click_becomes_two_steps(self):
+        slides = [Slide(index=1, body="# Slide", notes="First.\n[click]\nSecond.")]
+        steps = expand_slides_to_steps(slides)
+        assert len(steps) == 2
+        assert steps[0].click == 0
+        assert steps[0].notes == "First."
+        assert steps[1].click == 1
+        assert steps[1].notes == "Second."
+
+    def test_slide_with_no_notes_becomes_one_silent_step(self):
+        slides = [Slide(index=1, body="# Slide", notes=None)]
+        steps = expand_slides_to_steps(slides)
+        assert len(steps) == 1
+        assert steps[0].notes is None
+
+    def test_video_slide_produces_one_step(self):
+        slides = [Slide(index=1, body="# Slide", notes="Some notes.", video="demo.mov")]
+        steps = expand_slides_to_steps(slides)
+        assert len(steps) == 1
+        assert steps[0].video == "demo.mov"
+        assert steps[0].notes == "Some notes."
+
+    def test_video_slide_click_markers_stripped(self):
+        slides = [Slide(index=1, body="# Slide", notes="A.\n[click]\nB.", video="demo.mov")]
+        steps = expand_slides_to_steps(slides)
+        assert len(steps) == 1
+        assert "[click]" not in (steps[0].notes or "")
+
+    def test_video_slide_with_only_click_notes_becomes_none(self):
+        slides = [Slide(index=1, body="# Slide", notes="[click]", video="demo.mov")]
+        steps = expand_slides_to_steps(slides)
+        assert len(steps) == 1
+        assert steps[0].notes is None
+
+    def test_sequential_indexing_across_slides(self):
+        slides = [
+            Slide(index=1, body="A", notes="A.\n[click]\nB."),  # 2 steps
+            Slide(index=2, body="B", notes="C."),               # 1 step
+            Slide(index=3, body="C", notes="D.\n[click]\nE."),  # 2 steps
+        ]
+        steps = expand_slides_to_steps(slides)
+        assert len(steps) == 5
+        assert [s.index for s in steps] == [1, 2, 3, 4, 5]
+
+    def test_slide_index_preserved_across_steps(self):
+        slides = [
+            Slide(index=1, body="A", notes="A.\n[click]\nB."),
+            Slide(index=2, body="B", notes="C."),
+        ]
+        steps = expand_slides_to_steps(slides)
+        assert steps[0].slide_index == 1
+        assert steps[1].slide_index == 1
+        assert steps[2].slide_index == 2
+
+    def test_mixed_video_and_click_slides(self):
+        slides = [
+            Slide(index=1, body="A", notes="A.\n[click]\nB."),     # 2 steps
+            Slide(index=2, body="B", notes="C.", video="v.mov"),    # 1 step (video)
+            Slide(index=3, body="C", notes="D."),                   # 1 step
+        ]
+        steps = expand_slides_to_steps(slides)
+        assert len(steps) == 4
+        # steps[0] = slide 1 click 0, steps[1] = slide 1 click 1
+        # steps[2] = slide 2 (video), steps[3] = slide 3
+        assert steps[2].video == "v.mov"
+        assert steps[3].video is None
+
+    def test_empty_slides_list(self):
+        assert expand_slides_to_steps([]) == []
+
+    def test_no_clicks_returns_same_count_as_slides(self):
+        slides = [
+            Slide(index=1, body="A", notes="A."),
+            Slide(index=2, body="B", notes="B."),
+            Slide(index=3, body="C", notes=None),
+        ]
+        steps = expand_slides_to_steps(slides)
+        assert len(steps) == len(slides)

--- a/tests/test_slidev_parser.py
+++ b/tests/test_slidev_parser.py
@@ -146,3 +146,29 @@ class TestNoMarpDirectiveFiltering:
         slides = parse_slidev(str(md))
         # In Slidev mode, this comment is treated as a note, not filtered
         assert slides[0].notes == "_class: lead"
+
+
+class TestClickMarkers:
+    def test_click_markers_preserved_in_notes(self, tmp_path):
+        """The parser must NOT strip [click] markers — expansion happens downstream."""
+        md = tmp_path / "deck.md"
+        md.write_text(
+            "---\ntitle: Test\n---\n\n# Slide\n\n"
+            "<!-- First part.\n[click]\nSecond part. -->\n"
+        )
+        slides = parse_slidev(str(md))
+        assert slides[0].notes is not None
+        assert "[click]" in slides[0].notes
+        assert "First part." in slides[0].notes
+        assert "Second part." in slides[0].notes
+
+    def test_click_markers_in_multiple_comments(self, tmp_path):
+        """[click] in a second comment block is also preserved."""
+        md = tmp_path / "deck.md"
+        md.write_text(
+            "---\ntitle: Test\n---\n\n# Slide\n\n"
+            "<!-- Before click. -->\n<!-- [click] -->\n<!-- After click. -->\n"
+        )
+        slides = parse_slidev(str(md))
+        assert slides[0].notes is not None
+        assert "[click]" in slides[0].notes

--- a/tests/test_slidev_renderer.py
+++ b/tests/test_slidev_renderer.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from deck2video.slidev_renderer import check_slidev_cli, render_slidev_slides
+from deck2video.slidev_renderer import _parse_image_stem, check_slidev_cli, render_slidev_slides
 
 
 class TestCheckSlidevCli:
@@ -96,3 +96,85 @@ class TestRenderSlidevSlides:
         assert result[0].name == "1.png"
         assert result[1].name == "2.png"
         assert result[2].name == "3.png"
+
+    def test_with_clicks_appends_flag(self, tmp_path):
+        """--with-clicks should add the flag to the slidev export command."""
+        slides_dir = tmp_path / "slides"
+        slides_dir.mkdir()
+        (slides_dir / "1.png").touch()
+        (slides_dir / "2.png").touch()
+        (slides_dir / "2-1.png").touch()
+
+        with patch("shutil.which", return_value="/usr/bin/slidev"):
+            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_run:
+                result = render_slidev_slides("deck.md", tmp_path, expected_count=3, with_clicks=True)
+
+        cmd = mock_run.call_args[0][0]
+        assert "--with-clicks" in cmd
+        assert len(result) == 3
+
+    def test_without_clicks_no_flag(self, tmp_path):
+        """When with_clicks=False (default), --with-clicks should not appear."""
+        self._setup_pngs(tmp_path, 2)
+
+        with patch("shutil.which", return_value="/usr/bin/slidev"):
+            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_run:
+                render_slidev_slides("deck.md", tmp_path, expected_count=2)
+
+        cmd = mock_run.call_args[0][0]
+        assert "--with-clicks" not in cmd
+
+    def test_click_step_images_sorted_correctly(self, tmp_path):
+        """Click-step images like 2-1.png must sort between slide 2 and slide 3."""
+        slides_dir = tmp_path / "slides"
+        slides_dir.mkdir()
+        # Create out of filesystem order to verify sorting
+        for name in ["3.png", "1.png", "2-2.png", "2.png", "2-1.png"]:
+            (slides_dir / name).touch()
+
+        with patch("shutil.which", return_value="/usr/bin/slidev"):
+            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
+                result = render_slidev_slides("deck.md", tmp_path, expected_count=5, with_clicks=True)
+
+        names = [p.name for p in result]
+        assert names == ["1.png", "2.png", "2-1.png", "2-2.png", "3.png"]
+
+    def test_count_mismatch_with_clicks_prints_hint(self, tmp_path, capsys):
+        """Count mismatch when with_clicks=True should print a diagnostic hint."""
+        # Create 2 images but expect 4 (simulating click count mismatch)
+        slides_dir = tmp_path / "slides"
+        slides_dir.mkdir()
+        (slides_dir / "1.png").touch()
+        (slides_dir / "2.png").touch()
+
+        with patch("shutil.which", return_value="/usr/bin/slidev"):
+            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
+                with pytest.raises(SystemExit):
+                    render_slidev_slides("deck.md", tmp_path, expected_count=4, with_clicks=True)
+
+        captured = capsys.readouterr()
+        assert "click" in captured.err.lower() or "[click]" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# _parse_image_stem
+# ---------------------------------------------------------------------------
+
+class TestParseImageStem:
+    def test_plain_number(self):
+        assert _parse_image_stem("3") == (3, 0)
+
+    def test_click_step(self):
+        assert _parse_image_stem("3-1") == (3, 1)
+
+    def test_first_slide(self):
+        assert _parse_image_stem("1") == (1, 0)
+
+    def test_high_click_number(self):
+        assert _parse_image_stem("5-10") == (5, 10)
+
+    def test_sort_order(self):
+        """Sorting by _parse_image_stem should interleave click steps correctly."""
+        stems = ["3", "2-1", "1", "2", "2-2"]
+        sorted_stems = sorted(stems, key=_parse_image_stem)
+        assert sorted_stems == ["1", "2", "2-1", "2-2", "3"]

--- a/tests/test_slidev_renderer.py
+++ b/tests/test_slidev_renderer.py
@@ -124,6 +124,28 @@ class TestRenderSlidevSlides:
         cmd = mock_run.call_args[0][0]
         assert "--with-clicks" not in cmd
 
+    def test_dark_appends_flag(self, tmp_path):
+        """--dark should add the flag to the slidev export command."""
+        self._setup_pngs(tmp_path, 2)
+
+        with patch("shutil.which", return_value="/usr/bin/slidev"):
+            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_run:
+                render_slidev_slides("deck.md", tmp_path, expected_count=2, dark=True)
+
+        cmd = mock_run.call_args[0][0]
+        assert "--dark" in cmd
+
+    def test_without_dark_no_flag(self, tmp_path):
+        """When dark=False (default), --dark should not appear in the command."""
+        self._setup_pngs(tmp_path, 2)
+
+        with patch("shutil.which", return_value="/usr/bin/slidev"):
+            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_run:
+                render_slidev_slides("deck.md", tmp_path, expected_count=2)
+
+        cmd = mock_run.call_args[0][0]
+        assert "--dark" not in cmd
+
     def test_click_step_images_sorted_correctly(self, tmp_path):
         """Click-step images like 2-1.png must sort between slide 2 and slide 3."""
         slides_dir = tmp_path / "slides"

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -9,6 +9,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from deck2video.tts import (
+    _label,
     _play_audio,
     _split_sentences,
     apply_pronunciations,
@@ -759,3 +760,107 @@ class TestInteractiveRegenFailure:
         assert len(paths) == 1
         captured = capsys.readouterr()
         assert "Regeneration failed" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# _label helper
+# ---------------------------------------------------------------------------
+
+class TestLabel:
+    def test_slide_returns_slide_label(self):
+        from deck2video.models import Slide
+        slide = Slide(index=3, body="body", notes=None)
+        assert _label(slide) == "Slide 3"
+
+    def test_step_click_zero_returns_slide_label(self):
+        from deck2video.models import Step
+        step = Step(index=1, slide_index=3, click=0, notes=None)
+        assert _label(step) == "Slide 3"
+
+    def test_step_click_nonzero_includes_click(self):
+        from deck2video.models import Step
+        step = Step(index=2, slide_index=3, click=1, notes="Text.")
+        assert _label(step) == "Slide 3 click 1"
+
+    def test_step_higher_click(self):
+        from deck2video.models import Step
+        step = Step(index=5, slide_index=2, click=3, notes="Text.")
+        assert _label(step) == "Slide 2 click 3"
+
+
+# ---------------------------------------------------------------------------
+# generate_audio_for_slides with Step objects
+# ---------------------------------------------------------------------------
+
+class TestGenerateAudioForSteps:
+    """Verify that Step objects work correctly with generate_audio_for_slides."""
+
+    def _make_step(self, index, slide_index, click, notes=None):
+        from deck2video.models import Step
+        return Step(index=index, slide_index=slide_index, click=click, notes=notes)
+
+    def _setup_mocks(self):
+        mock_torch = MagicMock()
+        mock_torch.backends.mps.is_available.return_value = False
+        mock_torch.cuda.is_available.return_value = False
+        mock_torchaudio = MagicMock()
+        mock_model = MagicMock()
+        mock_model.sr = 24000
+        mock_model.device = "cpu"
+        mock_model.generate.return_value = mock_torch.zeros(1, 24000)
+        mock_torch.zeros.return_value.cpu.return_value = mock_torch.zeros(1, 24000)
+        mock_torch.cat.return_value = mock_torch.zeros(1, 24000)
+        return mock_torch, mock_torchaudio, mock_model
+
+    def test_step_audio_file_named_by_step_index(self, tmp_path):
+        """Audio files for steps use step.index (sequential), not slide_index."""
+        steps = [
+            self._make_step(1, slide_index=1, click=0, notes=None),
+            self._make_step(2, slide_index=1, click=1, notes=None),
+            self._make_step(3, slide_index=2, click=0, notes=None),
+        ]
+        mock_torch, mock_torchaudio, _ = self._setup_mocks()
+
+        with patch.dict("sys.modules", {"torch": mock_torch, "torchaudio": mock_torchaudio}):
+            with patch("deck2video.tts._load_model"):
+                from deck2video.tts import generate_audio_for_slides
+                paths = generate_audio_for_slides(steps, temp_dir=tmp_path, voice_path=None, hold_duration=1.0)
+
+        assert len(paths) == 3
+        assert paths[0].name == "audio_001.wav"
+        assert paths[1].name == "audio_002.wav"
+        assert paths[2].name == "audio_003.wav"
+
+    def test_step_label_shown_in_output(self, tmp_path, capsys):
+        """Progress messages should show click context for Steps with click > 0."""
+        steps = [
+            self._make_step(1, slide_index=2, click=0, notes=None),
+            self._make_step(2, slide_index=2, click=1, notes=None),
+        ]
+        mock_torch, mock_torchaudio, _ = self._setup_mocks()
+
+        with patch.dict("sys.modules", {"torch": mock_torch, "torchaudio": mock_torchaudio}):
+            with patch("deck2video.tts._load_model"):
+                from deck2video.tts import generate_audio_for_slides
+                generate_audio_for_slides(steps, temp_dir=tmp_path, voice_path=None, hold_duration=1.0)
+
+        captured = capsys.readouterr()
+        assert "Slide 2 click 1" in captured.out
+
+    def test_interactive_prompt_includes_label(self, tmp_path):
+        """Interactive prompt should include the step label."""
+        steps = [self._make_step(1, slide_index=3, click=2, notes="Hello.")]
+        mock_torch, mock_torchaudio, mock_model = self._setup_mocks()
+
+        with patch.dict("sys.modules", {"torch": mock_torch, "torchaudio": mock_torchaudio}):
+            with patch("deck2video.tts._load_model", return_value=mock_model), \
+                 patch("deck2video.tts._play_audio"), \
+                 patch("builtins.input", return_value="y") as mock_input:
+                from deck2video.tts import generate_audio_for_slides
+                generate_audio_for_slides(
+                    steps, temp_dir=tmp_path, voice_path=None,
+                    hold_duration=1.0, interactive=True,
+                )
+
+        prompt = mock_input.call_args[0][0]
+        assert "Slide 3 click 2" in prompt


### PR DESCRIPTION
Hello! Thanks for this project, absolutely saved my bacon. I needed support for <v-click> animations in Slidev, so I had an LLM modify the project to support this. Thought it might be useful to push it back upstream.

## Summary

This PR adds first-class support for Slidev's `v-click`/`v-clicks` progressive reveal animations, and adds a `--dark` flag for dark mode rendering.

## Click animation support

Slidev slides use `v-click` directives for step-by-step reveal. Previously, deck2video ignored click steps entirely — rendering one PNG per slide and reading `[click]` aloud as literal text.

### How it works

Add `[click]` markers in your speaker notes to indicate where each animation step falls in the narration:

```markdown
This is the first thing I say.

[click]

Now I reveal the second bullet.

[click]

And finally this.
```

deck2video expands each `[click]`-delimited fragment into a `Step` — pairing one click-state image with one narration fragment. The renderer is invoked with `--with-clicks` to produce the per-step PNGs. Downstream modules (TTS, assembler) see the same flat list interface they always have.

### Changes

- **`models.py`** — new `Step` dataclass, `split_notes_on_clicks()`, and `expand_slides_to_steps()` which converts `list[Slide]` → `list[Step]` (Slidev only; Marp is unaffected)
- **`slidev_renderer.py`** — `--with-clicks` flag, updated image sorting to handle `3-1.png`-style filenames, improved mismatch error messages
- **`__main__.py`** — orchestrates expansion; `--redo-slides` accepts original slide numbers and resolves to the correct steps
- **`tts.py`** — click-aware log labels (`Slide 3 click 2/4`) for interactive mode and progress output
- **`assembler.py`** — no changes needed; already operates on flat lists
- **No-click regression**: Slidev decks without `[click]` markers produce identical output to before

### Edge cases handled

- Click count mismatch between notes and slide directives → diagnostic error identifying the slide
- Slides with `video:` directive skip click expansion entirely
- Silent steps for notes-free click states

## Dark mode (`--dark`)

Passes `--dark` to `slidev export`, rendering slides with Slidev's dark theme.

```bash
python -m deck2video slides.md --format slidev --voice voice.wav --dark
```

## Tests

- New `tests/test_models.py` with full coverage of `Step`, `split_notes_on_clicks`, and `expand_slides_to_steps`
- Updated `test_slidev_renderer.py`, `test_slidev_parser.py`, `test_main.py`, `test_tts.py`