### PR TITLE
Preflight and lifecycle pass (ROADMAP 7/7 group)

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,11 +156,18 @@ python -m deck2video <input.md> [options]
 | `--pronunciations` | none | JSON file mapping words to phonetic respellings |
 | `--audio-padding` | `0` | Milliseconds of silence before and after each slide's audio (0–60000) |
 | `--with-clicks-audio-padding` | `0` | Milliseconds of silence around each click-step's audio (Slidev only, 0–60000) |
+| `--max-slides` | `500` | Refuse to render decks with more than N slides (1–100000) |
 | `--interactive`, `-i` | off | Review and approve each slide's TTS audio before continuing |
 | `--keep-temp` | off | Preserve intermediate files after rendering |
 | `--dark` | off | Render Slidev slides in dark mode (passes `--dark` to `slidev export`) |
 | `--reassemble` | off | Skip parse/render/TTS; assemble MP4 from existing temp dir files |
 | `--redo-slides` | none | Regenerate TTS for listed slides (e.g. `2,3,7` or `2-5,8`), then reassemble |
+
+There is also a `doctor` subcommand for one-shot environment checks:
+
+```bash
+python -m deck2video doctor   # verify ffmpeg, marp, slidev, GPU, disk, model cache
+```
 
 ### Examples
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -12,13 +12,13 @@ Legend: **B**ackend · **S**RE · **P**M · **Sec**urity · **D**X · **M**L · 
 |----|------|:------:|:-----:|:-:|:-:|:-:|:--:|:-:|:-:|:-:|
 | **E08** | Pin dependencies in requirements.txt with hashes | ✅ partial (versions pinned, hashes deferred) | **7/7** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | **E10** | Add timeouts to every subprocess call | ✅ done | **7/7** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| **E13** | Validate input markdown size + --max-slides guardrail | | **7/7** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **E13** | Validate input markdown size + --max-slides guardrail | ✅ done | **7/7** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | **E27** | Validate pronunciation JSON value types & cap size | ✅ done | **7/7** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | **E28** | Sanity-cap padding/hold-duration/fps numeric args | ✅ done | **7/7** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| **F14** | `doctor` preflight subcommand | | **7/7** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **F14** | `doctor` preflight subcommand | ✅ done | **7/7** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | **B05** | get_video_fps crashes on no-video-stream / 0-denom | ✅ done | **7/7** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| **B28** | Ctrl-C leaves orphan child processes (no SIGINT handler) | | **7/7** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
-| **B37** | Model never moved off GPU after pipeline ends | | **7/7** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **B28** | Ctrl-C leaves orphan child processes (no SIGINT handler) | ✅ done (POSIX; Windows partial) | **7/7** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| **B37** | Model never moved off GPU after pipeline ends | ✅ done | **7/7** | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
 | **E15** | Verify concat segments share pix_fmt/timebase before concat | ✅ done | **6/7** | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ |
 | **E40** | Drop -shortest in favor of explicit -t at frame boundary | ✅ done | **6/7** | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ |
 | **E46** | Per-slide deterministic seed for reproducible regens | ✅ done | **6/7** | ✓ | ✓ | ✓ | ✗ | ✓ | ✓ | ✓ |
@@ -212,9 +212,9 @@ Real fix is a normalization pass: re-encode all segments to identical `-video_tr
 
 ## Recommended Sequencing
 
-1. ✅ **First PR** (shipped): all 🟢 easy items as a single "reliability and validation pass".
-2. **Second PR** (~3 days, next up): **E13 + F14 + B28 + B37** — the remaining 7/7 group as a "preflight and lifecycle pass".
-3. **Third PR** (~1 week): **F04 + B17** as an "iteration speed + correctness" bundle (E46 already shipped in pass 1, so cache invalidation can rely on its determinism).
+1. ✅ **First PR** (shipped): all 🟢 easy items as a single "reliability and validation pass" (PR #4).
+2. ✅ **Second PR** (shipped): **E13 + F14 + B28 + B37** — the remaining 7/7 group as a "preflight and lifecycle pass" (this PR).
+3. **Third PR** (~1 week, next up): **F04 + B17** as an "iteration speed + correctness" bundle (E46 already shipped in pass 1, so cache invalidation can rely on its determinism).
 4. **Future**: **F08, F09, B40** each warrant their own design discussion before code.
 
 ## Methodology Notes

--- a/deck2video/__main__.py
+++ b/deck2video/__main__.py
@@ -12,6 +12,7 @@ import time
 from collections import Counter
 from pathlib import Path
 
+from . import process
 from .assembler import assemble_video
 from .detect import detect_format
 from .marp_parser import parse_marp
@@ -28,6 +29,15 @@ logger = logging.getLogger(__name__)
 # 10-min 1080p screencast .ts segment can be 150–300 MB, and concat
 # doubles peak usage briefly, so 5 GB is a realistic floor for typical decks.
 MIN_FREE_DISK_GB = 5.0
+
+# Markdown size cap. A real-world Marp/Slidev deck is well under this.
+# Anything larger is almost certainly a misuse (or an attacker trying to
+# starve the renderer for memory).
+MAX_INPUT_BYTES = 10 * 1024 * 1024  # 10 MiB
+
+# Default upper bound on slide count to keep accidental runs from kicking
+# off multi-hour renders. Override with --max-slides.
+DEFAULT_MAX_SLIDES = 500
 
 # Flags whose value is only meaningful when the TTS phase actually runs.
 # Used by --reassemble to warn about ignored input.
@@ -311,10 +321,47 @@ def _parse_slides(input_path: Path, fmt: str) -> list:
         return parse_marp(str(input_path))
 
 
+def _enforce_max_slides(slides: list, max_slides: int) -> None:
+    """Refuse to proceed if the parsed deck exceeds ``--max-slides``.
+
+    Prevents accidental multi-hour renders from a runaway / misformatted
+    deck. The cap also bounds memory use during step expansion and PNG
+    rendering. Override with ``--max-slides``.
+    """
+    if len(slides) > max_slides:
+        print(
+            f"Error: parsed {len(slides)} slides; --max-slides is {max_slides}. "
+            "If this is intentional, raise the limit with --max-slides N.",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+
 def main() -> None:
+    # Catch Ctrl-C and SIGTERM so subprocess process groups (marp/slidev/
+    # ffmpeg/Chromium) are reaped cleanly instead of orphaned.
+    process.install_signal_cleanup()
+
+    # Subcommand routing: `doctor` is the only special case today.
+    # Detected before argparse so the positional `input` arg doesn't
+    # require restructuring into a full subparser tree. We require an
+    # exact `["deck2video", "doctor"]` so a deck named "doctor.md" still
+    # routes to the normal pipeline, and stray flags like `doctor --help`
+    # don't get silently swallowed.
+    if sys.argv[1:] == ["doctor"]:
+        from .doctor import run_doctor
+        sys.exit(run_doctor())
+    if len(sys.argv) >= 2 and sys.argv[1] == "doctor":
+        print(
+            "Error: 'doctor' takes no arguments. Run as 'deck2video doctor'.",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
     parser = argparse.ArgumentParser(
         prog="deck2video",
-        description="Convert a Marp or Slidev markdown presentation into a narrated MP4 video.",
+        description="Convert a Marp or Slidev markdown presentation into a narrated MP4 video. "
+                    "Use 'deck2video doctor' to verify your environment before rendering.",
     )
     parser.add_argument("input", help="Path to the Marp or Slidev .md file")
     parser.add_argument("--output", help="Output MP4 path (default: <input>.mp4)")
@@ -352,6 +399,10 @@ def main() -> None:
     parser.add_argument("--dark", action="store_true",
                         help="Render Slidev slides in dark mode (passes --dark to slidev export; "
                              "ignored for Marp presentations)")
+    parser.add_argument("--max-slides", type=_ranged_int(1, 100000, "--max-slides"),
+                        default=DEFAULT_MAX_SLIDES, metavar="N",
+                        help=f"Refuse to render more than N slides (default: {DEFAULT_MAX_SLIDES}). "
+                             "Prevents runaway renders from a misformatted deck or an attacker.")
 
     rerun_group = parser.add_mutually_exclusive_group()
     rerun_group.add_argument("--reassemble", action="store_true",
@@ -375,6 +426,17 @@ def main() -> None:
     input_path = Path(args.input)
     if not input_path.exists():
         print(f"Error: {input_path} not found.", file=sys.stderr)
+        sys.exit(1)
+
+    # Cap markdown size — anything larger than a few MB is almost certainly
+    # a misuse and would starve the parser/renderer for memory.
+    input_size = input_path.stat().st_size
+    if input_size > MAX_INPUT_BYTES:
+        print(
+            f"Error: {input_path} is {input_size / (1024**2):.1f} MiB; "
+            f"max supported size is {MAX_INPUT_BYTES // (1024**2)} MiB.",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     output_path = Path(args.output) if args.output else input_path.with_suffix(".mp4")
@@ -447,6 +509,7 @@ def main() -> None:
             if fmt == "auto":
                 fmt = detect_format(str(input_path))
             slides = _parse_slides(input_path, fmt)
+            _enforce_max_slides(slides, args.max_slides)
             # Expand Slidev slides to steps so video_paths length matches image count
             items = expand_slides_to_steps(slides) if fmt == "slidev" else slides
             video_paths, fps = _resolve_videos_and_fps(items, input_path, args.fps)
@@ -482,6 +545,7 @@ def main() -> None:
 
             print("[redo] Parsing slides…")
             slides = _parse_slides(input_path, fmt)
+            _enforce_max_slides(slides, args.max_slides)
             print(f"  Found {len(slides)} slides")
 
             # For Slidev, expand to steps so indices align with temp files
@@ -647,6 +711,7 @@ def main() -> None:
             print("[1/4] Parsing slides…")
             t0 = time.monotonic()
             slides = _parse_slides(input_path, fmt)
+            _enforce_max_slides(slides, args.max_slides)
             logger.info("[1/4] Parse completed in %.2fs — %d slides", time.monotonic() - t0, len(slides))
 
             # For Slidev, expand slides into per-click steps

--- a/deck2video/assembler.py
+++ b/deck2video/assembler.py
@@ -9,6 +9,7 @@ import subprocess
 import sys
 from pathlib import Path
 
+from . import process
 from .utils import FFPROBE_TIMEOUT_S, get_audio_duration, get_video_duration
 
 logger = logging.getLogger(__name__)
@@ -83,7 +84,7 @@ def _make_segment(
     ]
     logger.debug("Segment %d command: %s", index, " ".join(cmd))
     try:
-        result = subprocess.run(
+        result = process.run(
             cmd, capture_output=True, text=True, timeout=FFMPEG_SEGMENT_TIMEOUT_S,
         )
     except subprocess.TimeoutExpired as exc:
@@ -152,7 +153,7 @@ def _make_video_segment(
     ]
     logger.debug("Video segment %d command: %s", index, " ".join(cmd))
     try:
-        result = subprocess.run(
+        result = process.run(
             cmd, capture_output=True, text=True, timeout=FFMPEG_SEGMENT_TIMEOUT_S,
         )
     except subprocess.TimeoutExpired as exc:
@@ -170,7 +171,7 @@ def _make_video_segment(
 def _probe_segment_streams(segment: Path) -> dict:
     """Return the parsed ffprobe stream info for a segment."""
     try:
-        result = subprocess.run(
+        result = process.run(
             [
                 "ffprobe",
                 "-v", "quiet",
@@ -311,7 +312,7 @@ def assemble_video(
     logger.debug("Concat command: %s", " ".join(cmd))
     print(f"  Concatenating {len(segments)} segments…")
     try:
-        result = subprocess.run(
+        result = process.run(
             cmd, capture_output=True, text=True, timeout=FFMPEG_CONCAT_TIMEOUT_S,
         )
     except subprocess.TimeoutExpired as exc:

--- a/deck2video/doctor.py
+++ b/deck2video/doctor.py
@@ -1,0 +1,243 @@
+"""Preflight subcommand: verify external tooling, GPU, model cache, and disk.
+
+``python -m deck2video doctor`` runs a sequence of independent checks and
+prints one line per check. Exits 0 if every check passes; non-zero if any
+check fails. The intent is to surface install / environment problems
+*before* the user starts a long render.
+
+Each check is a thin wrapper that returns a (status, message) tuple. They
+must not raise — failures are reported as :data:`_FAIL` with the diagnostic.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from . import process
+
+logger = logging.getLogger(__name__)
+
+
+def _ascii_only_stdout() -> bool:
+    """Return True if stdout can't encode unicode sigils (Windows cp1252, LANG=C)."""
+    enc = (getattr(sys.stdout, "encoding", None) or "").lower()
+    return "utf" not in enc
+
+
+# Status sigils. Unicode by default; ASCII fallback on encoding-limited
+# terminals so the output (which the user is reading *because* something
+# is broken) doesn't itself crash with UnicodeEncodeError.
+if _ascii_only_stdout():
+    _OK = "OK  "
+    _WARN = "WARN"
+    _FAIL = "FAIL"
+else:
+    _OK = "✓"
+    _WARN = "!"
+    _FAIL = "✗"
+
+
+def _install_hint(tool: str) -> str:
+    """Platform-tailored install hint for a missing tool."""
+    plat = sys.platform
+    if tool == "ffmpeg":
+        if plat == "darwin":
+            return "install: brew install ffmpeg"
+        if plat.startswith("linux"):
+            return "install: apt install ffmpeg / dnf install ffmpeg"
+        return "install: see https://ffmpeg.org/download.html"
+    if tool == "node":
+        if plat == "darwin":
+            return "install: brew install node"
+        if plat.startswith("linux"):
+            return "install: apt install nodejs npm"
+        return "install: see https://nodejs.org/"
+    return ""
+
+
+def _run_quick(cmd: list[str], *, timeout: float = 10.0) -> tuple[int, str]:
+    """Run a quick command and return (returncode, combined-output)."""
+    try:
+        result = process.run(
+            cmd, capture_output=True, text=True, timeout=timeout,
+        )
+    except FileNotFoundError:
+        return (127, f"{cmd[0]}: command not found")
+    except subprocess.TimeoutExpired:
+        return (124, f"{cmd[0]}: timed out after {timeout}s")
+    return (result.returncode, (result.stdout or "") + (result.stderr or ""))
+
+
+def check_python() -> tuple[str, str]:
+    """Confirm Python version is supported."""
+    major, minor = sys.version_info[:2]
+    version = f"{major}.{minor}.{sys.version_info.micro}"
+    if (major, minor) >= (3, 11):
+        return (_OK, f"Python {version}")
+    return (_FAIL, f"Python {version} — 3.11+ required")
+
+
+def check_ffmpeg() -> tuple[str, str]:
+    """Verify ffmpeg is on PATH and runnable."""
+    if shutil.which("ffmpeg") is None:
+        hint = _install_hint("ffmpeg")
+        return (_FAIL, f"ffmpeg not on PATH ({hint})")
+    rc, out = _run_quick(["ffmpeg", "-version"])
+    if rc != 0:
+        first = out.splitlines()[0] if out else "no output"
+        return (_FAIL, f"ffmpeg -version failed: {first}")
+    first_line = out.splitlines()[0] if out else "ffmpeg ok"
+    return (_OK, first_line)
+
+
+def check_ffprobe() -> tuple[str, str]:
+    """Verify ffprobe is on PATH and runnable."""
+    if shutil.which("ffprobe") is None:
+        return (_FAIL, "ffprobe not on PATH (usually ships with ffmpeg)")
+    rc, _ = _run_quick(["ffprobe", "-version"])
+    if rc != 0:
+        return (_FAIL, "ffprobe -version failed")
+    return (_OK, "ffprobe available")
+
+
+def check_marp() -> tuple[str, str]:
+    """marp-cli is reachable globally OR via npx."""
+    if shutil.which("marp"):
+        rc, out = _run_quick(["marp", "--version"])
+        if rc == 0:
+            return (_OK, f"marp-cli {out.strip().splitlines()[0]} (global)")
+        return (_WARN, "marp on PATH but --version failed")
+    if shutil.which("npx"):
+        return (_WARN, "marp-cli not installed globally; will fall back to npx (slower first run)")
+    return (_FAIL, f"Neither marp nor npx on PATH ({_install_hint('node')})")
+
+
+def check_slidev() -> tuple[str, str]:
+    """slidev CLI is reachable (only required for Slidev decks)."""
+    if shutil.which("slidev"):
+        return (_OK, "slidev (global)")
+    if shutil.which("npx"):
+        return (_WARN, "slidev not installed globally; will fall back to npx (Slidev decks only)")
+    return (_WARN, "Neither slidev nor npx on PATH — Slidev rendering will be unavailable")
+
+
+def check_gpu() -> tuple[str, str]:
+    """Detect a usable accelerator. Informational — CPU is fine, just slower."""
+    try:
+        import torch
+    except Exception as exc:
+        return (_WARN, f"torch not importable: {exc}")
+    if torch.cuda.is_available():
+        try:
+            name = torch.cuda.get_device_name(0)
+            return (_OK, f"CUDA available ({name})")
+        except Exception:
+            return (_OK, "CUDA available")
+    if hasattr(torch.backends, "mps") and torch.backends.mps.is_available():
+        return (_OK, "Apple MPS available")
+    return (_WARN, "No GPU detected — TTS will run on CPU (much slower)")
+
+
+def check_disk(min_free_gb: float = 5.0) -> tuple[str, str]:
+    """Verify the temp partition has enough free space for a render."""
+    target = Path(tempfile.gettempdir())
+    try:
+        free_gb = shutil.disk_usage(target).free / (1024 ** 3)
+    except OSError as exc:
+        return (_FAIL, f"disk_usage({target}) failed: {exc}")
+    if free_gb < min_free_gb:
+        ge = ">=" if _ascii_only_stdout() else "≥"
+        return (_FAIL, f"only {free_gb:.1f} GB free in {target} (need {ge} {min_free_gb} GB)")
+    return (_OK, f"{free_gb:.1f} GB free in {target}")
+
+
+def _hf_cache_root() -> Path:
+    """Return the HuggingFace cache root, honoring both env vars."""
+    # HUGGINGFACE_HUB_CACHE wins over HF_HOME per HuggingFace's own resolution.
+    explicit = os.environ.get("HUGGINGFACE_HUB_CACHE")
+    if explicit:
+        return Path(explicit)
+    return Path(os.environ.get("HF_HOME", Path.home() / ".cache" / "huggingface")) / "hub"
+
+
+def check_chatterbox_cache() -> tuple[str, str]:
+    """Detect a HuggingFace cache containing a Chatterbox checkpoint.
+
+    Informational only — first-run users haven't loaded a model yet so a
+    WARN here is expected. Tightened glob targets the canonical HF
+    snapshot path so we don't false-positive on unrelated repos containing
+    "chatterbox" in their name, and short-circuits on the first hit so
+    we don't walk gigabytes of unrelated cache files.
+    """
+    cache_root = _hf_cache_root()
+    # Real path is e.g. hub/models--ResembleAI--chatterbox/snapshots/<sha>/...
+    # Some users may have HF_HOME pointing at the parent (no `hub`), so
+    # check both. glob() on a non-existent path is a graceful no-op.
+    for root in (cache_root, cache_root.parent):
+        if not root.exists():
+            continue
+        match = next(root.glob("models--*chatterbox*"), None)
+        if match is not None:
+            return (_OK, f"chatterbox snapshot present ({match.name})")
+    return (_WARN, f"No chatterbox snapshot in {cache_root} — model will download on first run")
+
+
+# Order matters: hard requirements first, then soft / informational.
+# Each check returns (sigil, message). Result is the worst sigil seen.
+CHECKS = [
+    ("python", check_python),
+    ("ffmpeg", check_ffmpeg),
+    ("ffprobe", check_ffprobe),
+    ("marp-cli", check_marp),
+    ("slidev", check_slidev),
+    ("gpu", check_gpu),
+    ("disk", check_disk),
+    ("chatterbox cache", check_chatterbox_cache),
+]
+
+
+def run_doctor() -> int:
+    """Run all preflight checks. Return shell exit code."""
+    try:
+        from . import __version__ as version
+    except ImportError:
+        version = "(version unknown)"
+
+    print(f"deck2video doctor {version} — preflight checks\n")
+
+    # Width up to the longest check name so messages line up regardless
+    # of how many checks we add.
+    name_width = max(len(name) for name, _ in CHECKS)
+
+    overall_ok = True
+    overall_warn = False
+    for name, check in CHECKS:
+        try:
+            sigil, msg = check()
+        except Exception as exc:
+            sigil, msg = _FAIL, f"check raised: {exc!r}"
+            logger.exception("doctor check %s raised", name)
+        print(f"  {sigil}  {name:<{name_width}}  {msg}")
+        if sigil == _FAIL:
+            overall_ok = False
+        elif sigil == _WARN:
+            overall_warn = True
+
+    print()
+    if not overall_ok:
+        warn = "FAIL" if _ascii_only_stdout() else "✗"
+        print(f"Some required checks failed. Fix the items marked {warn} before rendering.",
+              file=sys.stderr)
+        return 1
+    if overall_warn:
+        warn = "WARN" if _ascii_only_stdout() else "!"
+        print(f"All required checks passed. Items marked {warn} are warnings — review them if you hit issues.")
+    else:
+        print("All checks passed.")
+    return 0

--- a/deck2video/marp_renderer.py
+++ b/deck2video/marp_renderer.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from . import process
+
 logger = logging.getLogger(__name__)
 
 # Generous: Chromium startup + rendering many slides can take a while.
@@ -55,7 +57,7 @@ def render_slides(input_md: str, temp_dir: Path, expected_count: int) -> list[Pa
     logger.debug("marp-cli command: %s", " ".join(cmd))
     print(f"  Running: {' '.join(cmd)}")
     try:
-        result = subprocess.run(cmd, stderr=subprocess.PIPE, text=True, timeout=RENDER_TIMEOUT_S)
+        result = process.run(cmd, stderr=subprocess.PIPE, text=True, timeout=RENDER_TIMEOUT_S)
     except subprocess.TimeoutExpired as exc:
         print(
             f"Error: marp-cli timed out after {RENDER_TIMEOUT_S}s. "

--- a/deck2video/process.py
+++ b/deck2video/process.py
@@ -1,0 +1,158 @@
+"""Subprocess execution with signal-aware child cleanup.
+
+Wraps :class:`subprocess.Popen` so that:
+
+* Each child runs in its own process group (POSIX) so we can ``killpg``
+  the whole tree on signal/timeout. Without this, killing the parent
+  Python process leaves grandchildren — npx → marp-cli → Chromium — alive.
+* On SIGINT / SIGTERM the registered process groups are signalled, then
+  reaped, before the parent exits with the conventional 128+signum code.
+
+POSIX-first: on Windows we set ``CREATE_NEW_PROCESS_GROUP`` and fall back
+to :meth:`Popen.terminate`. ``terminate`` only kills the direct child, so
+on Windows grandchildren spawned by ``npx`` may still survive — see B28
+follow-up.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import signal
+import subprocess
+import sys
+import threading
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Lock guarding the active-process registry. Individual ``set`` mutations
+# are GIL-atomic in CPython, but iterating a set while another thread
+# mutates it raises ``RuntimeError: Set changed size during iteration``
+# — possible because torch lazy-loads on a worker thread for some
+# accelerators. The lock makes the snapshot taken in ``_signal_handler``
+# correct under concurrency.
+_lock = threading.Lock()
+_active_processes: set[subprocess.Popen] = set()
+
+
+def _kill_proc_group(proc: subprocess.Popen, sig: int = signal.SIGTERM) -> None:
+    """Send ``sig`` to ``proc``'s process group on POSIX, terminate on Windows.
+
+    Swallows :class:`ProcessLookupError` and :class:`PermissionError` —
+    the child may have already exited (PID reuse race) or transitioned to
+    a uid we can't signal.
+    """
+    if os.name == "posix":
+        try:
+            # PID-reuse mitigation: if the child has already exited, its
+            # pid may belong to another process group. Skip in that case.
+            if proc.poll() is not None:
+                return
+            os.killpg(os.getpgid(proc.pid), sig)
+        except (ProcessLookupError, PermissionError):
+            pass
+    else:
+        try:
+            proc.terminate()
+        except (ProcessLookupError, OSError):
+            pass
+
+
+def _signal_handler(signum: int, frame: Any) -> None:
+    """Reap active children, then exit with the conventional 128+signum status."""
+    logger.warning("Received signal %d — terminating %d active subprocess(es)",
+                   signum, len(_active_processes))
+    print(
+        f"\nInterrupted (signal {signum}). Cleaning up child processes…",
+        file=sys.stderr,
+    )
+
+    # Restore default disposition first so a second Ctrl-C while we're
+    # cleaning up exits immediately instead of re-entering this handler.
+    signal.signal(signum, signal.SIG_DFL)
+
+    with _lock:
+        snapshot = list(_active_processes)
+
+    # Send SIGTERM, give children a moment, then SIGKILL the holdouts.
+    for proc in snapshot:
+        _kill_proc_group(proc, signal.SIGTERM)
+    for proc in snapshot:
+        try:
+            proc.wait(timeout=2)
+        except subprocess.TimeoutExpired:
+            _kill_proc_group(proc, signal.SIGKILL)
+            try:
+                proc.wait(timeout=1)
+            except subprocess.TimeoutExpired:
+                pass
+
+    # Use the conventional shell exit status: 128 + signum.
+    sys.exit(128 + signum)
+
+
+def install_signal_cleanup() -> None:
+    """Register SIGINT (and SIGTERM on POSIX) cleanup handlers.
+
+    Idempotent — safe to call repeatedly. Windows omits SIGTERM because
+    its default disposition there is unreliable.
+    """
+    signal.signal(signal.SIGINT, _signal_handler)
+    if os.name == "posix":
+        signal.signal(signal.SIGTERM, _signal_handler)
+
+
+def run(cmd: list[str], *, timeout: float | None = None, **kwargs) -> subprocess.CompletedProcess:
+    """Drop-in replacement for ``subprocess.run`` that:
+
+    * Starts the child in its own process group so we can reap descendants.
+    * Tracks the child in :data:`_active_processes` for signal-driven cleanup.
+    * On :class:`subprocess.TimeoutExpired`, signals the entire process group
+      (not just the direct child) before re-raising.
+
+    Returns a :class:`subprocess.CompletedProcess` with the same fields as
+    the standard library version. Most callers only inspect ``returncode``,
+    ``stdout``, and ``stderr``.
+    """
+    if os.name == "posix":
+        kwargs.setdefault("start_new_session", True)
+    elif os.name == "nt":
+        kwargs["creationflags"] = (
+            kwargs.get("creationflags", 0) | subprocess.CREATE_NEW_PROCESS_GROUP
+        )
+
+    # Re-implement subprocess.run's capture/input plumbing here so we can
+    # intercept the timeout cleanup at the process-group level.
+    capture_output = kwargs.pop("capture_output", False)
+    if capture_output:
+        kwargs.setdefault("stdout", subprocess.PIPE)
+        kwargs.setdefault("stderr", subprocess.PIPE)
+    input_data = kwargs.pop("input", None)
+    if input_data is not None:
+        kwargs.setdefault("stdin", subprocess.PIPE)
+
+    proc = subprocess.Popen(cmd, **kwargs)
+    with _lock:
+        _active_processes.add(proc)
+    try:
+        try:
+            stdout, stderr = proc.communicate(input=input_data, timeout=timeout)
+        except subprocess.TimeoutExpired:
+            _kill_proc_group(proc, signal.SIGTERM)
+            try:
+                # Bound the second communicate so a child holding the pipe
+                # FD open (Chromium grandchild on Windows is the classic
+                # case) doesn't hang us indefinitely.
+                stdout, stderr = proc.communicate(timeout=2)
+            except subprocess.TimeoutExpired:
+                _kill_proc_group(proc, signal.SIGKILL)
+                try:
+                    stdout, stderr = proc.communicate(timeout=1)
+                except subprocess.TimeoutExpired:
+                    stdout, stderr = b"", b""
+            raise subprocess.TimeoutExpired(cmd, timeout, output=stdout, stderr=stderr)
+        return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
+    finally:
+        with _lock:
+            _active_processes.discard(proc)

--- a/deck2video/slidev_renderer.py
+++ b/deck2video/slidev_renderer.py
@@ -8,6 +8,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from . import process
+
 logger = logging.getLogger(__name__)
 
 # Slidev export spins up a full Chromium; allow a generous budget.
@@ -82,7 +84,7 @@ def render_slidev_slides(
     logger.debug("slidev command: %s", " ".join(cmd))
     print(f"  Running: {' '.join(cmd)}")
     try:
-        result = subprocess.run(cmd, stderr=subprocess.PIPE, text=True, timeout=RENDER_TIMEOUT_S)
+        result = process.run(cmd, stderr=subprocess.PIPE, text=True, timeout=RENDER_TIMEOUT_S)
     except subprocess.TimeoutExpired as exc:
         print(
             f"Error: slidev export timed out after {RENDER_TIMEOUT_S}s. "

--- a/deck2video/tts.py
+++ b/deck2video/tts.py
@@ -10,8 +10,10 @@ import re
 import subprocess
 import sys
 import warnings
+from contextlib import ExitStack, contextmanager
 from pathlib import Path
 
+from . import process
 from .utils import generate_silent_wav
 
 logger = logging.getLogger(__name__)
@@ -89,7 +91,7 @@ def _play_audio(path: Path) -> None:
     else:
         print(f"  Warning: don't know how to play audio on {system}", file=sys.stderr)
         return
-    subprocess.run(cmd, capture_output=True)
+    process.run(cmd, capture_output=True)
 
 
 def _label(item) -> str:
@@ -177,8 +179,14 @@ def _flush_gpu_cache() -> None:
         torch.cuda.empty_cache()
 
 
-def _move_model_to_cpu(model):
-    """Move all TTS model components to CPU and free GPU memory."""
+def _move_model_to_cpu(model) -> None:
+    """Move all TTS model components to CPU and flush GPU memory.
+
+    Used for both the OOM-fallback retry and the end-of-pipeline cleanup
+    (see :func:`loaded_model`). Callers are responsible for any
+    context-specific log/print message — this function only mutates the
+    model's device state.
+    """
     # Access known attributes defensively so this works for both
     # ChatterboxTTS and ChatterboxMultilingualTTS.
     for attr in ("t3", "s3gen", "ve"):
@@ -189,10 +197,35 @@ def _move_model_to_cpu(model):
     if conds is not None:
         conds.to("cpu")
     model.device = "cpu"
-
     _flush_gpu_cache()
-    logger.warning("GPU OOM — moved model to CPU")
-    print("  Moved model to CPU due to GPU memory pressure")
+
+
+@contextmanager
+def loaded_model(device: str = "auto", language: str | None = None):
+    """Load the TTS model and guarantee GPU memory is released on exit.
+
+    Without this, ``model`` stays resident in GPU memory until the Python
+    process exits — fine for one-shot CLI runs, but a real leak for
+    interactive sessions, library callers, or back-to-back ``--redo-slides``
+    invocations in the same process. The context manager pairs every load
+    with a ``model.cpu() + flush_gpu_cache()`` cleanup.
+
+    Cleanup is best-effort: if the model is already half-torn-down (e.g.
+    during a crash) the failure is logged but not re-raised. ``_load_model``
+    is inside the try-block so a partial load (checkpoint downloaded, model
+    construction OOM'd) still triggers a GPU flush.
+    """
+    model = None
+    try:
+        model = _load_model(device, language)
+        yield model
+    finally:
+        if model is not None:
+            try:
+                _move_model_to_cpu(model)
+            except Exception:
+                logger.exception("Failed to move model to CPU during cleanup; ignoring")
+        _flush_gpu_cache()
 
 
 def _seed_for_slide(slide) -> int:
@@ -308,12 +341,46 @@ def generate_audio_for_slides(
     silent WAV of ``hold_duration`` seconds.
 
     If an out-of-memory error occurs on GPU, the model is automatically
-    moved to CPU and the failed slide is retried.
+    moved to CPU and the failed slide is retried. The model is moved to
+    CPU and GPU memory flushed when the function returns (success or
+    failure) — see :func:`loaded_model`.
     """
-    # Only import the heavy model when we actually need TTS.
+    # Only import the heavy model when we actually need TTS. ExitStack lets
+    # us conditionally enter the loaded_model context without duplicating
+    # the rest of the body for the no-TTS path.
     need_tts = any(s.notes for s in slides)
-    model = _load_model(device, language) if need_tts else None
+    with ExitStack() as stack:
+        model = stack.enter_context(loaded_model(device, language)) if need_tts else None
+        return _generate_audio_inner(
+            slides,
+            temp_dir=temp_dir,
+            voice_path=voice_path,
+            exaggeration=exaggeration,
+            cfg_weight=cfg_weight,
+            temperature=temperature,
+            hold_duration=hold_duration,
+            pronunciations=pronunciations,
+            interactive=interactive,
+            language=language,
+            model=model,
+        )
 
+
+def _generate_audio_inner(
+    slides,
+    *,
+    temp_dir: Path,
+    voice_path: str | None,
+    exaggeration: float,
+    cfg_weight: float,
+    temperature: float,
+    hold_duration: float,
+    pronunciations: list[tuple[re.Pattern, str]] | None,
+    interactive: bool,
+    language: str | None,
+    model,
+) -> list[Path]:
+    """Per-slide audio generation loop. Caller owns the model lifecycle."""
     import torch
     import torchaudio
 
@@ -364,7 +431,8 @@ def generate_audio_for_slides(
             except Exception as exc:
                 if on_gpu and _is_oom(exc):
                     # Fall back to CPU and retry this slide
-                    logger.warning("%s: GPU OOM, retrying on CPU", _label(slide))
+                    logger.warning("%s: GPU OOM, moved model to CPU", _label(slide))
+                    print("  Moved model to CPU due to GPU memory pressure")
                     _move_model_to_cpu(model)
                     on_gpu = False
                     try:

--- a/deck2video/utils.py
+++ b/deck2video/utils.py
@@ -10,6 +10,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from . import process
+
 logger = logging.getLogger(__name__)
 
 # ffprobe is fast; if it takes more than this, something is wrong.
@@ -145,7 +147,7 @@ def get_video_fps(path: Path) -> float:
     audio-only containers, or zero-denominator rates.
     """
     try:
-        result = subprocess.run(
+        result = process.run(
             [
                 "ffprobe",
                 "-v", "quiet",
@@ -193,7 +195,7 @@ def get_video_fps(path: Path) -> float:
 def _get_duration(path: Path) -> float:
     """Get duration of a media file in seconds using ffprobe."""
     try:
-        result = subprocess.run(
+        result = process.run(
             [
                 "ffprobe",
                 "-v", "quiet",

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -4,7 +4,29 @@
 
 ```
 python -m deck2video <input> [options]
+python -m deck2video doctor
 ```
+
+## Subcommands
+
+### `doctor`
+
+Run preflight checks (ffmpeg, ffprobe, marp, slidev, GPU, disk space, model cache) and exit. Useful before kicking off a long render or after a fresh install. Returns 0 when all required checks pass, 1 otherwise.
+
+```
+$ python -m deck2video doctor
+deck2video doctor — preflight checks
+
+  ✓  python            Python 3.11.14
+  ✓  ffmpeg            ffmpeg version 8.0.1
+  ✓  ffprobe           ffprobe available
+  !  marp-cli          marp-cli not installed globally; will fall back to npx
+  ✓  gpu               Apple MPS available
+  ✓  disk              42.1 GB free in /tmp
+  !  chatterbox cache  No chatterbox snapshot — model will download on first run
+```
+
+The doctor takes no arguments. On Windows or `LANG=C` terminals the unicode sigils fall back to `OK / WARN / FAIL`.
 
 ## Positional arguments
 
@@ -161,6 +183,16 @@ Milliseconds of silence added before and after each slide's audio.
 - **Range:** 0–60000 (values outside the range are rejected at parse time)
 - **Details:** A value of 300 adds 300ms before and 300ms after, extending each slide by 600ms total. See [Video Assembly](video-assembly.md#audio-padding).
 - **Example:** `--audio-padding 300`
+
+### `--max-slides`
+
+Refuse to render decks with more than N slides.
+
+- **Type:** integer
+- **Default:** `500`
+- **Range:** 1–100000
+- **Details:** Acts as a guardrail against accidental multi-hour renders from a misformatted or runaway deck. Override with a higher value if you genuinely need to render a long deck. Markdown files larger than 10 MiB are rejected outright before parse.
+- **Example:** `--max-slides 1000`
 
 ### `--with-clicks-audio-padding`
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -78,6 +78,16 @@ After setup completes, you can run deck2video directly:
 python -m deck2video presentation.md --voice voice-sample.wav
 ```
 
+## Verify your setup
+
+Before your first render, run the preflight checker. It verifies every external dependency in one shot and exits with a clear status:
+
+```bash
+python -m deck2video doctor
+```
+
+You'll see a checklist with `✓ / ! / ✗` (or `OK / WARN / FAIL` on non-UTF-8 terminals) for Python version, ffmpeg/ffprobe, marp/slidev, GPU detection, free disk space, and the Chatterbox model cache. Anything marked `✗` is a hard requirement to fix before rendering. Anything marked `!` is informational — common warnings on first run are "marp-cli not installed globally" (npx fallback works fine) and "No chatterbox snapshot in cache" (the model will download on your first TTS run).
+
 ## First run
 
 ### 1. Create a minimal slide deck

--- a/docs/interactive-mode.md
+++ b/docs/interactive-mode.md
@@ -62,6 +62,8 @@ Press `r` to hear the current audio again without regenerating. Useful if you we
 
 Press `q` to stop the pipeline. The process exits with code 0 (clean exit). No video is produced. Temp files may be preserved depending on the error handling path.
 
+Pressing **Ctrl-C** at any prompt also stops the pipeline. The signal handler sends SIGTERM to every active subprocess group (marp, slidev, ffmpeg, Chromium), waits up to 2 seconds for them to exit, then SIGKILLs the holdouts before exiting with status 130. A second Ctrl-C during cleanup exits immediately. The Chatterbox model is moved off GPU memory as part of cleanup. (On Windows, only the direct child receives `terminate()` — Chromium grandchildren may persist briefly.)
+
 ## Platform audio playback
 
 Interactive mode plays audio using your platform's native command:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -115,6 +115,25 @@ This means the parser (or step expansion) found a different number of steps than
 - Rewrite the speaker notes to be simpler and more conversational.
 - Break long notes into shorter sentences.
 
+## Run `deck2video doctor` first
+
+If the pipeline fails before reaching its first step, run `python -m deck2video doctor` for a one-shot check of every external dependency, GPU availability, disk space, and model cache state. It returns non-zero on the first hard failure so it's safe to chain in CI.
+
+## "parsed N slides; --max-slides is M"
+
+deck2video refuses to start a render whose parsed slide count exceeds `--max-slides` (default 500). Common causes:
+
+- A misformatted Markdown file with stray `---` separators that explode into thousands of "slides".
+- A genuinely large deck that needs an explicit override: `--max-slides 1000`.
+
+Markdown files larger than 10 MiB are rejected outright before parse — there's no way to disable that limit short of editing the source.
+
+## "Interrupted (signal 2). Cleaning up child processes…"
+
+Ctrl-C now triggers an orderly shutdown that sends SIGTERM to every active subprocess group (marp, slidev, ffmpeg, Chromium), gives them up to 2 seconds to exit, then SIGKILLs the holdouts. The pipeline then exits with status 130 (128 + SIGINT). Hitting Ctrl-C a second time during cleanup exits immediately via the default handler.
+
+On Windows, only the direct child receives `terminate()`; deeply-nested grandchildren (Chromium under npx under Slidev) may persist briefly.
+
 ## "Only X.YZ GB free in /tmp/...; need at least 5.0 GB"
 
 The pipeline performs a disk-space preflight before starting and aborts if `/tmp` (or your `--temp-dir`) has less than 5 GB free. A typical render produces hundreds of MB of intermediate `.ts` segments plus the final MP4, and concat doubles peak usage briefly.

--- a/docs/voice-and-tts.md
+++ b/docs/voice-and-tts.md
@@ -109,6 +109,10 @@ You'll see:
 
 No user intervention required.
 
+## GPU memory release on exit
+
+deck2video wraps the model load in a context manager that guarantees `model.cpu()` and a torch allocator flush when the pipeline finishes (success, failure, or Ctrl-C). Without this, the model stayed resident in GPU memory until the Python process exited — fine for one-shot CLI runs but a real leak for back-to-back `--redo-slides` invocations in the same process or anyone calling `generate_audio_for_slides` from a longer-lived host. Cleanup is best-effort: a torch internal failure during teardown is logged but not propagated, so the original exception (if any) reaches the user.
+
 ## Sentence splitting
 
 Long speaker notes are split into sentences before synthesis. Sentences are then grouped into chunks of 3 for each TTS call, and the resulting audio is concatenated.

--- a/tests/test_assembler.py
+++ b/tests/test_assembler.py
@@ -37,7 +37,7 @@ def _fail_result():
 
 class TestMakeSegment:
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_creates_segment_file(self, mock_run, mock_dur, tmp_path):
         img = tmp_path / "slide.001"
         img.touch()
@@ -48,7 +48,7 @@ class TestMakeSegment:
         assert seg == tmp_path / "segment_001.ts"
 
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_ffmpeg_command_structure(self, mock_run, mock_dur, tmp_path):
         img = tmp_path / "slide.001"
         img.touch()
@@ -74,7 +74,7 @@ class TestMakeSegment:
         assert _SCALE_PAD_FILTER in cmd
 
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_duration_passed_to_ffmpeg(self, mock_run, mock_dur, tmp_path):
         img = tmp_path / "slide.001"
         img.touch()
@@ -88,7 +88,7 @@ class TestMakeSegment:
         assert cmd[t_idx + 1] == "5.0000"
 
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_fail_result())
+    @patch("deck2video.assembler.process.run", return_value=_fail_result())
     def test_ffmpeg_failure_raises(self, mock_run, mock_dur, tmp_path):
         img = tmp_path / "slide.001"
         img.touch()
@@ -105,7 +105,7 @@ class TestMakeSegment:
 
 class TestMakeSegmentPadding:
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_no_adelay_when_padding_zero(self, mock_run, mock_dur, tmp_path):
         img = tmp_path / "slide.001"
         img.touch()
@@ -117,7 +117,7 @@ class TestMakeSegmentPadding:
         assert "-af" not in cmd
 
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_adelay_present_when_padding_set(self, mock_run, mock_dur, tmp_path):
         img = tmp_path / "slide.001"
         img.touch()
@@ -130,7 +130,7 @@ class TestMakeSegmentPadding:
         assert "adelay=500|500" in cmd[af_idx + 1]
 
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_duration_extended_by_double_padding(self, mock_run, mock_dur, tmp_path):
         img = tmp_path / "slide.001"
         img.touch()
@@ -151,7 +151,7 @@ class TestMakeSegmentPadding:
 class TestMakeVideoSegment:
     @patch("deck2video.assembler.get_video_duration", return_value=10.0)
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_creates_segment(self, mock_run, mock_adur, mock_vdur, tmp_path):
         video = tmp_path / "demo.mov"
         video.touch()
@@ -163,7 +163,7 @@ class TestMakeVideoSegment:
 
     @patch("deck2video.assembler.get_video_duration", return_value=10.0)
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_uses_video_duration_when_longer(self, mock_run, mock_adur, mock_vdur, tmp_path):
         video = tmp_path / "demo.mov"
         video.touch()
@@ -179,7 +179,7 @@ class TestMakeVideoSegment:
 
     @patch("deck2video.assembler.get_video_duration", return_value=5.0)
     @patch("deck2video.assembler.get_audio_duration", return_value=12.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_tpad_when_audio_longer(self, mock_run, mock_adur, mock_vdur, tmp_path):
         """When audio is longer than video, tpad should freeze last frame."""
         video = tmp_path / "demo.mov"
@@ -203,7 +203,7 @@ class TestMakeVideoSegment:
 
     @patch("deck2video.assembler.get_video_duration", return_value=10.0)
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_no_tpad_when_video_longer(self, mock_run, mock_adur, mock_vdur, tmp_path):
         video = tmp_path / "demo.mov"
         video.touch()
@@ -219,7 +219,7 @@ class TestMakeVideoSegment:
 
     @patch("deck2video.assembler.get_video_duration", return_value=10.0)
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_maps_video_and_audio_streams(self, mock_run, mock_adur, mock_vdur, tmp_path):
         video = tmp_path / "demo.mov"
         video.touch()
@@ -237,7 +237,7 @@ class TestMakeVideoSegment:
 
     @patch("deck2video.assembler.get_video_duration", return_value=10.0)
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_fail_result())
+    @patch("deck2video.assembler.process.run", return_value=_fail_result())
     def test_ffmpeg_failure_raises(self, mock_run, mock_adur, mock_vdur, tmp_path):
         video = tmp_path / "demo.mov"
         video.touch()
@@ -255,7 +255,7 @@ class TestMakeVideoSegment:
 class TestMakeVideoSegmentPadding:
     @patch("deck2video.assembler.get_video_duration", return_value=10.0)
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_adelay_present_when_padding_set(self, mock_run, mock_adur, mock_vdur, tmp_path):
         video = tmp_path / "demo.mov"
         video.touch()
@@ -269,7 +269,7 @@ class TestMakeVideoSegmentPadding:
 
     @patch("deck2video.assembler.get_video_duration", return_value=10.0)
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_no_adelay_when_padding_zero(self, mock_run, mock_adur, mock_vdur, tmp_path):
         video = tmp_path / "demo.mov"
         video.touch()
@@ -282,7 +282,7 @@ class TestMakeVideoSegmentPadding:
 
     @patch("deck2video.assembler.get_video_duration", return_value=10.0)
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_duration_extended_by_double_padding(self, mock_run, mock_adur, mock_vdur, tmp_path):
         video = tmp_path / "demo.mov"
         video.touch()
@@ -298,7 +298,7 @@ class TestMakeVideoSegmentPadding:
 
     @patch("deck2video.assembler.get_video_duration", return_value=5.0)
     @patch("deck2video.assembler.get_audio_duration", return_value=3.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_tpad_triggered_by_padding(self, mock_run, mock_adur, mock_vdur, tmp_path):
         """Padding can cause padded audio to exceed video duration, triggering tpad."""
         video = tmp_path / "demo.mov"
@@ -334,7 +334,7 @@ class TestAssembleVideo:
         return images, audios
 
     @patch("deck2video.assembler.get_audio_duration", return_value=3.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_creates_concat_file(self, mock_run, mock_dur, tmp_path):
         images, audios = self._make_files(tmp_path, 2)
         output = tmp_path / "out.mp4"
@@ -349,7 +349,7 @@ class TestAssembleVideo:
         assert "segment_002.ts" in content
 
     @patch("deck2video.assembler.get_audio_duration", return_value=3.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_calls_ffmpeg_for_each_segment_plus_concat(self, mock_run, mock_dur, tmp_path):
         images, audios = self._make_files(tmp_path, 3)
         output = tmp_path / "out.mp4"
@@ -362,7 +362,7 @@ class TestAssembleVideo:
 
     @patch("deck2video.assembler.get_video_duration", return_value=10.0)
     @patch("deck2video.assembler.get_audio_duration", return_value=3.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_mixed_image_and_video_segments(self, mock_run, mock_adur, mock_vdur, tmp_path):
         images, audios = self._make_files(tmp_path, 3)
         vid = tmp_path / "demo.mov"
@@ -387,7 +387,7 @@ class TestAssembleVideo:
         assert "-loop" in third_cmd
 
     @patch("deck2video.assembler.get_audio_duration", return_value=3.0)
-    @patch("deck2video.assembler.subprocess.run")
+    @patch("deck2video.assembler.process.run")
     def test_concat_failure_raises(self, mock_run, mock_dur, tmp_path):
         images, audios = self._make_files(tmp_path, 1)
         output = tmp_path / "out.mp4"
@@ -405,7 +405,7 @@ class TestAssembleVideo:
             assemble_video(images, audios, output, temp_dir=tmp_path, fps=24)
 
     @patch("deck2video.assembler.get_audio_duration", return_value=3.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_videos_default_none(self, mock_run, mock_dur, tmp_path):
         """When videos param omitted, all segments should be image-based."""
         images, audios = self._make_files(tmp_path, 2)
@@ -420,7 +420,7 @@ class TestAssembleVideo:
             assert "-loop" in cmd
 
     @patch("deck2video.assembler.get_audio_duration", return_value=3.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_audio_padding_passed_to_segments(self, mock_run, mock_dur, tmp_path):
         images, audios = self._make_files(tmp_path, 2)
         output = tmp_path / "out.mp4"
@@ -435,7 +435,7 @@ class TestAssembleVideo:
             assert "adelay=250|250" in cmd[af_idx + 1]
 
     @patch("deck2video.assembler.get_audio_duration", return_value=3.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_per_step_padding_list(self, mock_run, mock_dur, tmp_path):
         """Per-step padding list applies a different value to each segment."""
         images, audios = self._make_files(tmp_path, 3)
@@ -467,7 +467,7 @@ class TestAssembleVideo:
 
 class TestFrameAlignment:
     @patch("deck2video.assembler.get_audio_duration", return_value=5.01)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_duration_rounded_up_to_whole_frame(self, mock_run, mock_dur, tmp_path):
         """5.01s @ 24fps → 121 frames → 5.0417s (rounded up, never down)."""
         img = tmp_path / "slide.001"
@@ -483,7 +483,7 @@ class TestFrameAlignment:
         assert cmd[t_idx + 1] == f"{121/24:.4f}"
 
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_no_shortest_flag(self, mock_run, mock_dur, tmp_path):
         """-shortest is removed in favor of an explicit -t to prevent pad clipping."""
         img = tmp_path / "slide.001"
@@ -496,7 +496,7 @@ class TestFrameAlignment:
         assert "-shortest" not in cmd
 
     @patch("deck2video.assembler.get_audio_duration", return_value=5.0)
-    @patch("deck2video.assembler.subprocess.run", return_value=_ok_result())
+    @patch("deck2video.assembler.process.run", return_value=_ok_result())
     def test_apad_uses_whole_dur(self, mock_run, mock_dur, tmp_path):
         """apad must include whole_dur so it doesn't produce infinite audio."""
         img = tmp_path / "slide.001"
@@ -526,7 +526,7 @@ class TestTimeoutWrapping:
         audio.touch()
 
         with patch(
-            "deck2video.assembler.subprocess.run",
+            "deck2video.assembler.process.run",
             side_effect=subprocess.TimeoutExpired(cmd=["ffmpeg"], timeout=600),
         ):
             with pytest.raises(RuntimeError, match="timed out"):
@@ -560,7 +560,7 @@ class TestVerifyConcatCompatibility:
     def test_single_segment_short_circuits(self, tmp_path):
         from deck2video.assembler import _verify_concat_compatibility
         # Should not even call ffprobe with a single segment.
-        with patch("deck2video.assembler.subprocess.run") as mock_run:
+        with patch("deck2video.assembler.process.run") as mock_run:
             _verify_concat_compatibility([tmp_path / "segment_001.ts"])
         mock_run.assert_not_called()
 
@@ -569,7 +569,7 @@ class TestVerifyConcatCompatibility:
         seg1 = tmp_path / "segment_001.ts"
         seg2 = tmp_path / "segment_002.ts"
         result = self._ffprobe(self._video_stream(), self._audio_stream())
-        with patch("deck2video.assembler.subprocess.run", return_value=result):
+        with patch("deck2video.assembler.process.run", return_value=result):
             _verify_concat_compatibility([seg1, seg2])  # no exception
 
     def test_mismatched_pix_fmt_raises(self, tmp_path):
@@ -594,7 +594,7 @@ class TestVerifyConcatCompatibility:
                 })
             return r
 
-        with patch("deck2video.assembler.subprocess.run", side_effect=fake_run):
+        with patch("deck2video.assembler.process.run", side_effect=fake_run):
             with pytest.raises(RuntimeError, match="not bit-identical"):
                 _verify_concat_compatibility([seg1, seg2])
 
@@ -619,7 +619,7 @@ class TestVerifyConcatCompatibility:
                 })
             return r
 
-        with patch("deck2video.assembler.subprocess.run", side_effect=fake_run):
+        with patch("deck2video.assembler.process.run", side_effect=fake_run):
             with pytest.raises(RuntimeError, match="not bit-identical"):
                 _verify_concat_compatibility([seg1, seg2])
 

--- a/tests/test_doctor.py
+++ b/tests/test_doctor.py
@@ -1,0 +1,256 @@
+"""Tests for deck2video.doctor — the preflight subcommand."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deck2video import doctor
+from deck2video.doctor import (
+    _FAIL,
+    _OK,
+    _WARN,
+    check_chatterbox_cache,
+    check_disk,
+    check_ffmpeg,
+    check_ffprobe,
+    check_gpu,
+    check_marp,
+    check_python,
+    check_slidev,
+    run_doctor,
+)
+
+
+# ---------------------------------------------------------------------------
+# Individual checks — failure paths
+# ---------------------------------------------------------------------------
+
+class TestCheckFfmpeg:
+    def test_passes_when_ffmpeg_present(self):
+        with patch("deck2video.doctor.shutil.which", return_value="/usr/bin/ffmpeg"), \
+             patch("deck2video.doctor._run_quick", return_value=(0, "ffmpeg version 6.1\n")):
+            sigil, msg = check_ffmpeg()
+        assert sigil == _OK
+        assert "ffmpeg" in msg
+
+    def test_fails_when_ffmpeg_missing(self):
+        with patch("deck2video.doctor.shutil.which", return_value=None):
+            sigil, msg = check_ffmpeg()
+        assert sigil == _FAIL
+        assert "PATH" in msg
+
+    def test_fails_when_ffmpeg_version_errors(self):
+        with patch("deck2video.doctor.shutil.which", return_value="/usr/bin/ffmpeg"), \
+             patch("deck2video.doctor._run_quick", return_value=(1, "boom")):
+            sigil, _ = check_ffmpeg()
+        assert sigil == _FAIL
+
+
+class TestCheckFfprobe:
+    def test_passes(self):
+        with patch("deck2video.doctor.shutil.which", return_value="/usr/bin/ffprobe"), \
+             patch("deck2video.doctor._run_quick", return_value=(0, "ok")):
+            assert check_ffprobe()[0] == _OK
+
+    def test_fails_when_missing(self):
+        with patch("deck2video.doctor.shutil.which", return_value=None):
+            assert check_ffprobe()[0] == _FAIL
+
+
+class TestCheckMarp:
+    def test_global_marp_is_ok(self):
+        def which(name):
+            return "/usr/local/bin/marp" if name == "marp" else None
+        with patch("deck2video.doctor.shutil.which", side_effect=which), \
+             patch("deck2video.doctor._run_quick", return_value=(0, "marp 4.0.0\n")):
+            sigil, msg = check_marp()
+        assert sigil == _OK
+        assert "global" in msg
+
+    def test_npx_fallback_is_warn(self):
+        def which(name):
+            return "/usr/local/bin/npx" if name == "npx" else None
+        with patch("deck2video.doctor.shutil.which", side_effect=which):
+            sigil, msg = check_marp()
+        assert sigil == _WARN
+        assert "npx" in msg
+
+    def test_no_marp_no_npx_is_fail(self):
+        with patch("deck2video.doctor.shutil.which", return_value=None):
+            sigil, _ = check_marp()
+        assert sigil == _FAIL
+
+
+class TestCheckSlidev:
+    def test_global_slidev_is_ok(self):
+        with patch("deck2video.doctor.shutil.which",
+                   side_effect=lambda n: "/usr/local/bin/slidev" if n == "slidev" else None):
+            assert check_slidev()[0] == _OK
+
+    def test_npx_only_is_warn(self):
+        with patch("deck2video.doctor.shutil.which",
+                   side_effect=lambda n: "/usr/local/bin/npx" if n == "npx" else None):
+            assert check_slidev()[0] == _WARN
+
+    def test_neither_is_warn_not_fail(self):
+        # Slidev is optional — missing is a warn, not a fail.
+        with patch("deck2video.doctor.shutil.which", return_value=None):
+            assert check_slidev()[0] == _WARN
+
+
+class TestCheckPython:
+    def test_python_311_is_ok(self):
+        # sys.version_info is a named tuple; a regular tuple works for
+        # numeric subscripting (sys.version_info[:2]) and .micro access.
+        from collections import namedtuple
+        VI = namedtuple("VI", "major minor micro releaselevel serial")
+        with patch("deck2video.doctor.sys.version_info", VI(3, 11, 5, "final", 0)):
+            assert check_python()[0] == _OK
+
+    def test_python_310_is_fail(self):
+        from collections import namedtuple
+        VI = namedtuple("VI", "major minor micro releaselevel serial")
+        with patch("deck2video.doctor.sys.version_info", VI(3, 10, 0, "final", 0)):
+            sigil, msg = check_python()
+        assert sigil == _FAIL
+        assert "3.11" in msg
+
+
+class TestCheckDisk:
+    def test_enough_disk(self, tmp_path):
+        usage = MagicMock()
+        usage.free = 50 * 1024 ** 3
+        with patch("deck2video.doctor.shutil.disk_usage", return_value=usage):
+            assert check_disk(min_free_gb=5.0)[0] == _OK
+
+    def test_low_disk_fails(self, tmp_path):
+        usage = MagicMock()
+        usage.free = int(0.5 * 1024 ** 3)
+        with patch("deck2video.doctor.shutil.disk_usage", return_value=usage):
+            sigil, msg = check_disk(min_free_gb=5.0)
+        assert sigil == _FAIL
+        assert "0.5 GB" in msg
+
+
+class TestCheckGpu:
+    def test_no_torch_is_warn(self):
+        with patch.dict("sys.modules", {"torch": None}):
+            sigil, _ = check_gpu()
+        assert sigil == _WARN
+
+    def test_cuda_is_ok(self):
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = True
+        mock_torch.cuda.get_device_name.return_value = "NVIDIA H100"
+        mock_torch.backends.mps.is_available.return_value = False
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            sigil, msg = check_gpu()
+        assert sigil == _OK
+        assert "H100" in msg
+
+    def test_cpu_only_is_warn(self):
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = False
+        mock_torch.backends.mps.is_available.return_value = False
+        with patch.dict("sys.modules", {"torch": mock_torch}):
+            sigil, _ = check_gpu()
+        assert sigil == _WARN
+
+
+class TestCheckChatterboxCache:
+    def test_missing_cache_dir_is_warn(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HF_HOME", str(tmp_path / "no-such-dir"))
+        assert check_chatterbox_cache()[0] == _WARN
+
+    def test_no_chatterbox_in_cache_is_warn(self, tmp_path, monkeypatch):
+        (tmp_path / "some-other-model").mkdir()
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
+        assert check_chatterbox_cache()[0] == _WARN
+
+    def test_chatterbox_present_is_ok_canonical_layout(self, tmp_path, monkeypatch):
+        """HF cache layout is HF_HOME/hub/models--Org--Repo/..."""
+        hub = tmp_path / "hub"
+        hub.mkdir()
+        (hub / "models--ResembleAI--chatterbox").mkdir()
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
+        monkeypatch.delenv("HUGGINGFACE_HUB_CACHE", raising=False)
+        assert check_chatterbox_cache()[0] == _OK
+
+    def test_chatterbox_present_is_ok_flat_layout(self, tmp_path, monkeypatch):
+        """Some users point HF_HOME directly at the snapshots dir; tolerate that."""
+        (tmp_path / "models--ResembleAI--chatterbox").mkdir()
+        monkeypatch.setenv("HF_HOME", str(tmp_path))
+        monkeypatch.delenv("HUGGINGFACE_HUB_CACHE", raising=False)
+        assert check_chatterbox_cache()[0] == _OK
+
+    def test_huggingface_hub_cache_overrides_hf_home(self, tmp_path, monkeypatch):
+        """HUGGINGFACE_HUB_CACHE wins over HF_HOME (matches HF's own resolution)."""
+        explicit = tmp_path / "explicit"
+        explicit.mkdir()
+        (explicit / "models--ResembleAI--chatterbox").mkdir()
+        # HF_HOME points somewhere wrong but HUGGINGFACE_HUB_CACHE wins.
+        monkeypatch.setenv("HF_HOME", str(tmp_path / "wrong"))
+        monkeypatch.setenv("HUGGINGFACE_HUB_CACHE", str(explicit))
+        assert check_chatterbox_cache()[0] == _OK
+
+
+# ---------------------------------------------------------------------------
+# run_doctor — overall exit code
+# ---------------------------------------------------------------------------
+
+class TestRunDoctor:
+    def test_all_pass_returns_zero(self, capsys):
+        ok = (_OK, "fine")
+        with patch("deck2video.doctor.CHECKS", [
+            ("python", lambda: ok),
+            ("ffmpeg", lambda: ok),
+        ]):
+            rc = run_doctor()
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "All checks passed" in captured.out
+
+    def test_any_fail_returns_one(self, capsys):
+        with patch("deck2video.doctor.CHECKS", [
+            ("python", lambda: (_OK, "fine")),
+            ("ffmpeg", lambda: (_FAIL, "missing")),
+        ]):
+            rc = run_doctor()
+        assert rc == 1
+        captured = capsys.readouterr()
+        assert "Some required checks failed" in captured.err
+
+    def test_warnings_only_returns_zero(self, capsys):
+        with patch("deck2video.doctor.CHECKS", [
+            ("python", lambda: (_OK, "fine")),
+            ("gpu", lambda: (_WARN, "cpu only")),
+        ]):
+            rc = run_doctor()
+        assert rc == 0
+        captured = capsys.readouterr()
+        assert "warnings" in captured.out.lower()
+
+    def test_check_that_raises_is_treated_as_fail(self, capsys):
+        def boom():
+            raise RuntimeError("kaboom")
+        with patch("deck2video.doctor.CHECKS", [("explosive", boom)]):
+            rc = run_doctor()
+        assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# main() routing — `deck2video doctor` is detected before argparse
+# ---------------------------------------------------------------------------
+
+class TestDoctorRouting:
+    def test_doctor_arg_runs_doctor_not_main_pipeline(self):
+        """`python -m deck2video doctor` must short-circuit to run_doctor."""
+        from deck2video.__main__ import main
+        with patch("deck2video.doctor.run_doctor", return_value=0) as mock_doc:
+            with patch("sys.argv", ["deck2video", "doctor"]):
+                with pytest.raises(SystemExit) as excinfo:
+                    main()
+        assert excinfo.value.code == 0
+        mock_doc.assert_called_once()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -815,6 +815,59 @@ class TestRangedValidators:
 
 
 # ---------------------------------------------------------------------------
+# E13 — --max-slides + input size cap
+# ---------------------------------------------------------------------------
+
+class TestMaxSlides:
+    """E13 — refuse to render decks larger than --max-slides."""
+
+    def test_under_limit_proceeds(self, tmp_path):
+        from deck2video.__main__ import main
+        md = tmp_path / "deck.md"
+        md.write_text("# Slide 1\n")
+        # Default max is 500; 2 slides is well under.
+        patches = _patch_pipeline()
+        with patch("sys.argv", ["deck2video", str(md)]):
+            import contextlib
+            with contextlib.ExitStack() as stack:
+                for target, mock_obj in patches.items():
+                    stack.enter_context(patch(target, mock_obj))
+                main()  # no SystemExit
+
+    def test_over_limit_aborts(self, tmp_path, capsys):
+        from deck2video.__main__ import main
+        from deck2video.models import Slide
+        md = tmp_path / "deck.md"
+        md.write_text("# Slide\n")
+        # 6 slides with --max-slides=3 → must abort.
+        slides = [Slide(index=i, body="b", notes=None, video=None) for i in range(1, 7)]
+        patches = _patch_pipeline(**{
+            "deck2video.__main__.parse_marp": MagicMock(return_value=slides),
+        })
+        with patch("sys.argv", ["deck2video", str(md), "--max-slides", "3"]):
+            import contextlib
+            with contextlib.ExitStack() as stack:
+                for target, mock_obj in patches.items():
+                    stack.enter_context(patch(target, mock_obj))
+                with pytest.raises(SystemExit):
+                    main()
+        captured = capsys.readouterr()
+        assert "max-slides" in captured.err
+
+    def test_oversized_input_file_aborts(self, tmp_path, capsys):
+        """E13 — markdown larger than MAX_INPUT_BYTES is rejected before parse."""
+        from deck2video.__main__ import MAX_INPUT_BYTES, main
+        md = tmp_path / "huge.md"
+        # MAX_INPUT_BYTES + 1 byte
+        md.write_bytes(b"# Slide\n" + b"a" * MAX_INPUT_BYTES)
+        with patch("sys.argv", ["deck2video", str(md)]):
+            with pytest.raises(SystemExit):
+                main()
+        captured = capsys.readouterr()
+        assert "max supported size" in captured.err.lower()
+
+
+# ---------------------------------------------------------------------------
 # B12 — disk-space preflight
 # ---------------------------------------------------------------------------
 

--- a/tests/test_marp_renderer.py
+++ b/tests/test_marp_renderer.py
@@ -53,7 +53,7 @@ class TestRenderSlides:
         mock_result.returncode = 0
 
         with patch("deck2video.marp_renderer.shutil.which", side_effect=which):
-            with patch("deck2video.marp_renderer.subprocess.run", return_value=mock_result) as mock_run:
+            with patch("deck2video.marp_renderer.process.run", return_value=mock_result) as mock_run:
                 render_slides("/tmp/deck.md", tmp_path, expected_count=3)
                 cmd = mock_run.call_args[0][0]
                 assert cmd[0] == "marp"
@@ -70,7 +70,7 @@ class TestRenderSlides:
         mock_result.returncode = 0
 
         with patch("deck2video.marp_renderer.shutil.which", side_effect=which):
-            with patch("deck2video.marp_renderer.subprocess.run", return_value=mock_result) as mock_run:
+            with patch("deck2video.marp_renderer.process.run", return_value=mock_result) as mock_run:
                 render_slides("/tmp/deck.md", tmp_path, expected_count=2)
                 cmd = mock_run.call_args[0][0]
                 assert cmd[0] == "npx"
@@ -83,7 +83,7 @@ class TestRenderSlides:
         mock_result.returncode = 0
 
         with patch("deck2video.marp_renderer.shutil.which", return_value="/usr/bin/marp"):
-            with patch("deck2video.marp_renderer.subprocess.run", return_value=mock_result):
+            with patch("deck2video.marp_renderer.process.run", return_value=mock_result):
                 images = render_slides("/tmp/deck.md", tmp_path, expected_count=3)
 
         assert len(images) == 3
@@ -97,7 +97,7 @@ class TestRenderSlides:
         mock_result.stderr = "marp error"
 
         with patch("deck2video.marp_renderer.shutil.which", return_value="/usr/bin/marp"):
-            with patch("deck2video.marp_renderer.subprocess.run", return_value=mock_result):
+            with patch("deck2video.marp_renderer.process.run", return_value=mock_result):
                 with pytest.raises(RuntimeError, match="marp-cli exited"):
                     render_slides("/tmp/deck.md", tmp_path, expected_count=3)
 
@@ -108,7 +108,7 @@ class TestRenderSlides:
         mock_result.returncode = 0
 
         with patch("deck2video.marp_renderer.shutil.which", return_value="/usr/bin/marp"):
-            with patch("deck2video.marp_renderer.subprocess.run", return_value=mock_result):
+            with patch("deck2video.marp_renderer.process.run", return_value=mock_result):
                 with pytest.raises(SystemExit):
                     render_slides("/tmp/deck.md", tmp_path, expected_count=3)
 
@@ -118,7 +118,7 @@ class TestRenderSlides:
         mock_result.returncode = 0
 
         with patch("deck2video.marp_renderer.shutil.which", return_value="/usr/bin/marp"):
-            with patch("deck2video.marp_renderer.subprocess.run", return_value=mock_result) as mock_run:
+            with patch("deck2video.marp_renderer.process.run", return_value=mock_result) as mock_run:
                 render_slides("/tmp/deck.md", tmp_path, expected_count=1)
                 cmd = mock_run.call_args[0][0]
                 assert "--images" in cmd

--- a/tests/test_process.py
+++ b/tests/test_process.py
@@ -1,0 +1,124 @@
+"""Tests for deck2video.process — subprocess wrapper with signal cleanup."""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deck2video import process
+
+
+class TestRun:
+    def test_returns_completed_process(self):
+        """Equivalent to subprocess.run for the happy path."""
+        result = process.run([sys.executable, "-c", "print('hello')"], capture_output=True, text=True)
+        assert result.returncode == 0
+        assert "hello" in result.stdout
+
+    def test_returncode_propagates(self):
+        result = process.run([sys.executable, "-c", "import sys; sys.exit(7)"], capture_output=True)
+        assert result.returncode == 7
+
+    def test_stderr_captured(self):
+        result = process.run(
+            [sys.executable, "-c", "import sys; sys.stderr.write('ouch')"],
+            capture_output=True,
+            text=True,
+        )
+        assert "ouch" in result.stderr
+
+    def test_input_passed_through(self):
+        result = process.run(
+            [sys.executable, "-c", "import sys; sys.stdout.write(sys.stdin.read())"],
+            capture_output=True,
+            text=True,
+            input="from-test",
+        )
+        assert "from-test" in result.stdout
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX-only: start_new_session check")
+    def test_starts_new_session_on_posix(self):
+        """The child must be in its own session/process group so we can killpg."""
+        result = process.run(
+            [sys.executable, "-c",
+             "import os; print(os.getpgrp() == os.getpid())"],
+            capture_output=True, text=True,
+        )
+        assert "True" in result.stdout
+
+    def test_timeout_raises_and_kills_child(self):
+        """A child that ignores SIGTERM must still be killed by the wrapper."""
+        with pytest.raises(subprocess.TimeoutExpired):
+            process.run(
+                [sys.executable, "-c", "import time; time.sleep(60)"],
+                timeout=0.5,
+                capture_output=True,
+            )
+
+    def test_active_processes_set_drains_on_success(self):
+        process._active_processes.clear()
+        process.run([sys.executable, "-c", "pass"])
+        assert len(process._active_processes) == 0
+
+    def test_active_processes_set_drains_on_timeout(self):
+        process._active_processes.clear()
+        with pytest.raises(subprocess.TimeoutExpired):
+            process.run(
+                [sys.executable, "-c", "import time; time.sleep(60)"],
+                timeout=0.3,
+            )
+        assert len(process._active_processes) == 0
+
+
+class TestKillProcGroup:
+    @pytest.mark.skipif(os.name != "posix", reason="killpg is POSIX only")
+    def test_killpg_called_with_sigterm(self):
+        proc = MagicMock()
+        proc.pid = 12345
+        proc.poll.return_value = None  # still running
+        with patch("os.killpg") as mock_killpg, \
+             patch("os.getpgid", return_value=12345):
+            process._kill_proc_group(proc)
+        mock_killpg.assert_called_once_with(12345, signal.SIGTERM)
+
+    @pytest.mark.skipif(os.name != "posix", reason="killpg is POSIX only")
+    def test_already_exited_skips_killpg(self):
+        """PID-reuse mitigation: if the child has exited, don't signal at all."""
+        proc = MagicMock()
+        proc.pid = 12345
+        proc.poll.return_value = 0  # already exited
+        with patch("os.killpg") as mock_killpg:
+            process._kill_proc_group(proc)
+        mock_killpg.assert_not_called()
+
+    @pytest.mark.skipif(os.name != "posix", reason="killpg is POSIX only")
+    def test_swallows_process_lookup_error(self):
+        """If the child exits between poll() and killpg, error must not propagate."""
+        proc = MagicMock()
+        proc.pid = 12345
+        proc.poll.return_value = None
+        with patch("os.getpgid", return_value=12345), \
+             patch("os.killpg", side_effect=ProcessLookupError):
+            process._kill_proc_group(proc)  # no exception
+
+
+class TestInstallSignalCleanup:
+    def test_sigint_handler_is_our_function(self):
+        """install_signal_cleanup registers our handler for SIGINT."""
+        import signal as _sig
+        original = _sig.getsignal(_sig.SIGINT)
+        try:
+            process.install_signal_cleanup()
+            assert _sig.getsignal(_sig.SIGINT) is process._signal_handler
+        finally:
+            _sig.signal(_sig.SIGINT, original)
+
+    def test_idempotent(self):
+        """Calling twice doesn't raise."""
+        process.install_signal_cleanup()
+        process.install_signal_cleanup()  # no exception

--- a/tests/test_slidev_renderer.py
+++ b/tests/test_slidev_renderer.py
@@ -41,7 +41,7 @@ class TestRenderSlidevSlides:
         self._setup_pngs(tmp_path, 2)
 
         with patch("shutil.which", side_effect=lambda x: "/usr/bin/slidev" if x == "slidev" else None):
-            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_run:
+            with patch("deck2video.slidev_renderer.process.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_run:
                 result = render_slidev_slides("deck.md", tmp_path, expected_count=2)
 
         cmd = mock_run.call_args[0][0]
@@ -60,7 +60,7 @@ class TestRenderSlidevSlides:
             return None
 
         with patch("shutil.which", side_effect=which_mock):
-            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
+            with patch("deck2video.slidev_renderer.process.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
                 with patch("deck2video.slidev_renderer.check_slidev_cli"):
                     result = render_slidev_slides("deck.md", tmp_path, expected_count=1)
 
@@ -68,7 +68,7 @@ class TestRenderSlidevSlides:
 
     def test_raises_on_nonzero_exit(self, tmp_path):
         with patch("shutil.which", return_value="/usr/bin/slidev"):
-            with patch("subprocess.run", return_value=MagicMock(returncode=1, stdout="", stderr="error")):
+            with patch("deck2video.slidev_renderer.process.run", return_value=MagicMock(returncode=1, stdout="", stderr="error")):
                 with pytest.raises(RuntimeError, match="exited with code 1"):
                     render_slidev_slides("deck.md", tmp_path, expected_count=1)
 
@@ -77,7 +77,7 @@ class TestRenderSlidevSlides:
         self._setup_pngs(tmp_path, 1)
 
         with patch("shutil.which", return_value="/usr/bin/slidev"):
-            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
+            with patch("deck2video.slidev_renderer.process.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
                 with pytest.raises(SystemExit):
                     render_slidev_slides("deck.md", tmp_path, expected_count=3)
 
@@ -90,7 +90,7 @@ class TestRenderSlidevSlides:
         (slides_dir / "2.png").touch()
 
         with patch("shutil.which", return_value="/usr/bin/slidev"):
-            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
+            with patch("deck2video.slidev_renderer.process.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
                 result = render_slidev_slides("deck.md", tmp_path, expected_count=3)
 
         assert result[0].name == "1.png"
@@ -106,7 +106,7 @@ class TestRenderSlidevSlides:
         (slides_dir / "2-1.png").touch()
 
         with patch("shutil.which", return_value="/usr/bin/slidev"):
-            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_run:
+            with patch("deck2video.slidev_renderer.process.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_run:
                 result = render_slidev_slides("deck.md", tmp_path, expected_count=3, with_clicks=True)
 
         cmd = mock_run.call_args[0][0]
@@ -118,7 +118,7 @@ class TestRenderSlidevSlides:
         self._setup_pngs(tmp_path, 2)
 
         with patch("shutil.which", return_value="/usr/bin/slidev"):
-            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_run:
+            with patch("deck2video.slidev_renderer.process.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_run:
                 render_slidev_slides("deck.md", tmp_path, expected_count=2)
 
         cmd = mock_run.call_args[0][0]
@@ -129,7 +129,7 @@ class TestRenderSlidevSlides:
         self._setup_pngs(tmp_path, 2)
 
         with patch("shutil.which", return_value="/usr/bin/slidev"):
-            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_run:
+            with patch("deck2video.slidev_renderer.process.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_run:
                 render_slidev_slides("deck.md", tmp_path, expected_count=2, dark=True)
 
         cmd = mock_run.call_args[0][0]
@@ -140,7 +140,7 @@ class TestRenderSlidevSlides:
         self._setup_pngs(tmp_path, 2)
 
         with patch("shutil.which", return_value="/usr/bin/slidev"):
-            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_run:
+            with patch("deck2video.slidev_renderer.process.run", return_value=MagicMock(returncode=0, stdout="", stderr="")) as mock_run:
                 render_slidev_slides("deck.md", tmp_path, expected_count=2)
 
         cmd = mock_run.call_args[0][0]
@@ -155,7 +155,7 @@ class TestRenderSlidevSlides:
             (slides_dir / name).touch()
 
         with patch("shutil.which", return_value="/usr/bin/slidev"):
-            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
+            with patch("deck2video.slidev_renderer.process.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
                 result = render_slidev_slides("deck.md", tmp_path, expected_count=5, with_clicks=True)
 
         names = [p.name for p in result]
@@ -170,7 +170,7 @@ class TestRenderSlidevSlides:
         (slides_dir / "2.png").touch()
 
         with patch("shutil.which", return_value="/usr/bin/slidev"):
-            with patch("subprocess.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
+            with patch("deck2video.slidev_renderer.process.run", return_value=MagicMock(returncode=0, stdout="", stderr="")):
                 with pytest.raises(SystemExit):
                     render_slidev_slides("deck.md", tmp_path, expected_count=4, with_clicks=True)
 

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -133,7 +133,7 @@ class TestPlayAudio:
         p = tmp_path / "test.wav"
         p.write_bytes(b"fake")
         with patch("deck2video.tts.platform.system", return_value="Darwin"), \
-             patch("deck2video.tts.subprocess.run") as mock_run:
+             patch("deck2video.tts.process.run") as mock_run:
             _play_audio(p)
         mock_run.assert_called_once_with(["afplay", str(p)], capture_output=True)
 
@@ -141,7 +141,7 @@ class TestPlayAudio:
         p = tmp_path / "test.wav"
         p.write_bytes(b"fake")
         with patch("deck2video.tts.platform.system", return_value="Linux"), \
-             patch("deck2video.tts.subprocess.run") as mock_run:
+             patch("deck2video.tts.process.run") as mock_run:
             _play_audio(p)
         mock_run.assert_called_once_with(["aplay", str(p)], capture_output=True)
 
@@ -158,7 +158,7 @@ class TestPlayAudio:
         p = tmp_path / "test.wav"
         p.write_bytes(b"fake")
         with patch("deck2video.tts.platform.system", return_value="HaikuOS"), \
-             patch("deck2video.tts.subprocess.run") as mock_run:
+             patch("deck2video.tts.process.run") as mock_run:
             _play_audio(p)
         mock_run.assert_not_called()
         captured = capsys.readouterr()
@@ -693,7 +693,10 @@ class TestMultiChunkAndOOM:
                     slides, temp_dir=tmp_path, voice_path=None, hold_duration=2.0,
                 )
 
-        mock_move.assert_called_once()
+        # _move_model_to_cpu is called twice: once for the OOM fallback,
+        # once for end-of-pipeline cleanup via the loaded_model context
+        # manager (B37). Asserting >= 1 keeps the test resilient to that.
+        assert mock_move.call_count >= 1
         assert len(paths) == 1
 
     def test_gpu_oom_cpu_retry_also_fails(self, tmp_path):
@@ -932,6 +935,46 @@ class TestSeedForSlide:
 # ---------------------------------------------------------------------------
 # B01 — generate_audio_for_slides must NOT mutate slide.notes in place
 # ---------------------------------------------------------------------------
+
+class TestLoadedModelContext:
+    """B37 — loaded_model context manager guarantees CPU+flush on exit."""
+
+    def test_normal_exit_moves_to_cpu(self):
+        """On normal context exit, model is moved to CPU and GPU cache flushed."""
+        from deck2video.tts import loaded_model
+        mock_model = MagicMock()
+        with patch("deck2video.tts._load_model", return_value=mock_model), \
+             patch("deck2video.tts._move_model_to_cpu") as mock_move, \
+             patch("deck2video.tts._flush_gpu_cache") as mock_flush:
+            with loaded_model(device="cpu", language=None) as m:
+                assert m is mock_model
+        mock_move.assert_called_once_with(mock_model)
+        # _flush_gpu_cache also runs on exit (after del); >= 1 call.
+        assert mock_flush.call_count >= 1
+
+    def test_exception_in_body_still_cleans_up(self):
+        """If the user's code raises inside the with-block, cleanup still runs."""
+        from deck2video.tts import loaded_model
+        mock_model = MagicMock()
+        with patch("deck2video.tts._load_model", return_value=mock_model), \
+             patch("deck2video.tts._move_model_to_cpu") as mock_move, \
+             patch("deck2video.tts._flush_gpu_cache"):
+            with pytest.raises(ValueError):
+                with loaded_model(device="cpu", language=None):
+                    raise ValueError("user code crashed")
+        mock_move.assert_called_once_with(mock_model)
+
+    def test_cleanup_failure_is_swallowed(self):
+        """If _move_model_to_cpu raises during cleanup, the error is logged not propagated."""
+        from deck2video.tts import loaded_model
+        mock_model = MagicMock()
+        with patch("deck2video.tts._load_model", return_value=mock_model), \
+             patch("deck2video.tts._move_model_to_cpu", side_effect=RuntimeError("torch crashed")), \
+             patch("deck2video.tts._flush_gpu_cache"):
+            # Must not re-raise the cleanup failure.
+            with loaded_model(device="cpu", language=None):
+                pass
+
 
 class TestNoMutateSlideNotes:
     def test_pronunciations_do_not_mutate_input(self, tmp_path):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -143,7 +143,7 @@ def _mock_ffprobe_result(duration_str: str):
 
 class TestGetAudioDuration:
     def test_returns_duration(self, tmp_path):
-        with patch("deck2video.utils.subprocess.run", return_value=_mock_ffprobe_result("3.456")):
+        with patch("deck2video.utils.process.run", return_value=_mock_ffprobe_result("3.456")):
             d = get_audio_duration(tmp_path / "audio.wav")
             assert d == pytest.approx(3.456)
 
@@ -151,14 +151,14 @@ class TestGetAudioDuration:
         result = MagicMock()
         result.returncode = 1
         result.stderr = "error"
-        with patch("deck2video.utils.subprocess.run", return_value=result):
+        with patch("deck2video.utils.process.run", return_value=result):
             with pytest.raises(RuntimeError, match="ffprobe failed"):
                 get_audio_duration(tmp_path / "audio.wav")
 
 
 class TestGetVideoDuration:
     def test_returns_duration(self, tmp_path):
-        with patch("deck2video.utils.subprocess.run", return_value=_mock_ffprobe_result("12.5")):
+        with patch("deck2video.utils.process.run", return_value=_mock_ffprobe_result("12.5")):
             d = get_video_duration(tmp_path / "video.mp4")
             assert d == pytest.approx(12.5)
 
@@ -177,26 +177,26 @@ class TestGetVideoFps:
         return result
 
     def test_integer_fps(self, tmp_path):
-        with patch("deck2video.utils.subprocess.run", return_value=self._mock_fps_result("30/1")):
+        with patch("deck2video.utils.process.run", return_value=self._mock_fps_result("30/1")):
             assert get_video_fps(tmp_path / "v.mp4") == pytest.approx(30.0)
 
     def test_fractional_fps(self, tmp_path):
-        with patch("deck2video.utils.subprocess.run", return_value=self._mock_fps_result("30000/1001")):
+        with patch("deck2video.utils.process.run", return_value=self._mock_fps_result("30000/1001")):
             assert get_video_fps(tmp_path / "v.mp4") == pytest.approx(29.97, rel=1e-2)
 
     def test_24fps(self, tmp_path):
-        with patch("deck2video.utils.subprocess.run", return_value=self._mock_fps_result("24/1")):
+        with patch("deck2video.utils.process.run", return_value=self._mock_fps_result("24/1")):
             assert get_video_fps(tmp_path / "v.mp4") == pytest.approx(24.0)
 
     def test_60fps(self, tmp_path):
-        with patch("deck2video.utils.subprocess.run", return_value=self._mock_fps_result("60/1")):
+        with patch("deck2video.utils.process.run", return_value=self._mock_fps_result("60/1")):
             assert get_video_fps(tmp_path / "v.mp4") == pytest.approx(60.0)
 
     def test_ffprobe_failure_raises(self, tmp_path):
         result = MagicMock()
         result.returncode = 1
         result.stderr = "no such file"
-        with patch("deck2video.utils.subprocess.run", return_value=result):
+        with patch("deck2video.utils.process.run", return_value=result):
             with pytest.raises(RuntimeError, match="ffprobe failed"):
                 get_video_fps(tmp_path / "v.mp4")
 
@@ -206,14 +206,14 @@ class TestGetVideoFps:
         result.returncode = 0
         result.stdout = json.dumps({"streams": []})
         result.stderr = ""
-        with patch("deck2video.utils.subprocess.run", return_value=result):
+        with patch("deck2video.utils.process.run", return_value=result):
             with pytest.raises(RuntimeError, match="No video stream"):
                 get_video_fps(tmp_path / "audio.m4a")
 
     def test_zero_denominator_raises_clean_error(self, tmp_path):
         """A 0/0 frame rate (legal in malformed video) must not become ZeroDivisionError."""
         with patch(
-            "deck2video.utils.subprocess.run",
+            "deck2video.utils.process.run",
             return_value=self._mock_fps_result("0/0"),
         ):
             with pytest.raises(RuntimeError, match="zero-denominator"):
@@ -222,7 +222,7 @@ class TestGetVideoFps:
     def test_malformed_rate_string_raises_clean_error(self, tmp_path):
         """A frame rate without a slash must not be a confusing unpacking error."""
         with patch(
-            "deck2video.utils.subprocess.run",
+            "deck2video.utils.process.run",
             return_value=self._mock_fps_result("not-a-fraction"),
         ):
             with pytest.raises(RuntimeError, match="frame rate"):
@@ -241,7 +241,7 @@ class TestGetAudioDurationWav:
         wav = tmp_path / "audio.wav"
         # Generate a real silent WAV — its duration is exact.
         generate_silent_wav(wav, duration=2.5, sample_rate=24000)
-        with patch("deck2video.utils.subprocess.run") as mock_run:
+        with patch("deck2video.utils.process.run") as mock_run:
             d = get_audio_duration(wav)
         assert d == pytest.approx(2.5, abs=1e-6)
         mock_run.assert_not_called()  # Did NOT touch ffprobe
@@ -251,7 +251,7 @@ class TestGetAudioDurationWav:
         m4a = tmp_path / "audio.m4a"
         m4a.write_bytes(b"fake")
         with patch(
-            "deck2video.utils.subprocess.run",
+            "deck2video.utils.process.run",
             return_value=_mock_ffprobe_result("3.456"),
         ) as mock_run:
             d = get_audio_duration(m4a)
@@ -263,7 +263,7 @@ class TestGetAudioDurationWav:
         wav = tmp_path / "fake.wav"
         wav.write_bytes(b"not a riff")
         with patch(
-            "deck2video.utils.subprocess.run",
+            "deck2video.utils.process.run",
             return_value=_mock_ffprobe_result("1.0"),
         ) as mock_run:
             d = get_audio_duration(wav)


### PR DESCRIPTION
## Summary

Implements the four remaining 7/7 unanimous items from [ROADMAP.md](../blob/main/ROADMAP.md):

- **E13** — `--max-slides` guardrail (default 500) + 10 MiB markdown size cap
- **F14** — `python -m deck2video doctor` preflight subcommand
- **B28** — Subprocess process-group plumbing + SIGINT/SIGTERM handlers (no more orphan Chromium / ffmpeg processes on Ctrl-C)
- **B37** — `loaded_model` context manager guarantees model.cpu() + flush_gpu_cache() on exit (no more leaked GPU memory)

**+1168/-93 across 20 files (5 new). 368 tests passing (321 inherited from PR #4 + 47 new).**

⚠️ **Stacked on [PR #4](../pull/4) — `reliability-and-validation-pass` is the base branch.** Once #4 merges, this PR's diff against main collapses to just the new work.

## What's in this PR

### `deck2video/process.py` (new — 156 lines)
Subprocess wrapper that:
- Uses `start_new_session=True` (POSIX) / `CREATE_NEW_PROCESS_GROUP` (Windows) so children form their own group
- Tracks active children in a `threading.Lock`-guarded set
- Installs SIGINT (and SIGTERM on POSIX) handler that SIGTERMs every active group, waits 2s, then SIGKILLs holdouts
- Exits with the conventional `128 + signum` status
- Has a PID-reuse guard (`proc.poll()` before each killpg)
- Bounds the second `communicate()` in the timeout cleanup so a Chromium grandchild holding the pipe FD open can't hang us

All `subprocess.run` callsites in `marp_renderer.py`, `slidev_renderer.py`, `assembler.py`, `utils.py`, and `tts.py` migrated to `process.run`.

### `deck2video/doctor.py` (new — 186 lines)
`python -m deck2video doctor` runs 8 independent checks: Python version, ffmpeg, ffprobe, marp-cli, slidev, GPU detection, disk space, Chatterbox model cache. Each returns a `(sigil, message)` tuple. Output uses unicode sigils (`✓ ! ✗`) by default, falls back to ASCII (`OK / WARN / FAIL`) when `sys.stdout.encoding` isn't UTF-8 (Windows cp1252, `LANG=C`). Exit code is 0 on all-pass / warnings-only, 1 on any required-check failure. Honors both `HF_HOME` and `HUGGINGFACE_HUB_CACHE`. Platform-tailored install hints (brew/apt/dnf/Windows).

### `deck2video/tts.py` — `loaded_model` context manager
Pairs every `_load_model` with a guaranteed `_move_model_to_cpu` + `_flush_gpu_cache`. `_load_model` is *inside* the try block so a partial-load failure (checkpoint downloaded but model construction OOM'd) still triggers cleanup. `generate_audio_for_slides` uses `ExitStack` to conditionally enter the context only when TTS is actually needed; the no-TTS fast path doesn't pay the load cost.

### `deck2video/__main__.py`
- New `MAX_INPUT_BYTES = 10 MiB` check before parse
- New `--max-slides` argparse arg (range 1–100000, default 500) + `_enforce_max_slides()` called after every parse site
- Doctor subcommand routing: exact-match `sys.argv[1:] == ["doctor"]` so a deck literally named "doctor.md" still routes to the normal pipeline
- `process.install_signal_cleanup()` called at startup

## Multi-agent review

Six parallel reviewers vetted the staged diff:
- 3 simplify-style agents
- 1 process / signal management engineer
- 1 CLI / DX designer (focused on the doctor command)
- 1 resource lifecycle / Python concurrency engineer (focused on `loaded_model`)

**Notable applied fixes:**
- ASCII sigil fallback for non-UTF-8 stdout
- `_active_processes` thread-safety lock
- HF cache glob tightened from `**/*chatterbox*` to `models--*chatterbox*` with short-circuit
- SIGKILL escalation via `os.killpg` (was reaching only the direct child via `Popen.kill`)
- `proc.poll()` PID-reuse guard before killpg
- Bounded second `communicate()` in timeout path
- `sys.exit(128 + signum)` instead of fragile SIG_DFL re-raise
- Dropped misleading `del model` (caller's frame holds the reference; cleanup is via `_move_to_cpu`)
- Moved `_load_model` inside try so partial-load failures still flush GPU
- Doctor: dynamic name column width, version line, platform-aware install hints
- Doctor: exact-arg-match routing so `doctor --help` and `doctor my-deck.md` aren't silently swallowed
- Reverted accidental OOM-message routing from stderr back to stdout

**Filtered as false positives or scope creep:**
- "Use argparse subparsers for doctor" — bigger restructure (related to E01, score 4/7, didn't make any cut)
- "Drop ExitStack for plain if/else" — reviewers split; ExitStack is more resilient when more contexts get added
- "Add doctor --json mode / retry semantics" — explicitly in 🟡 group
- Windows process-tree termination — documented limitation; full fix needs `taskkill /T /F`, deferred

## Test plan

- [x] All 321 pre-existing tests still pass.
- [x] 47 new tests covering the four new items.
- [x] `pytest` clean: 368 passed.
- [x] End-to-end smoke: `python -m deck2video doctor` runs and reports correctly on this dev machine.
- [x] `deck2video doctor --help` and `deck2video doctor extra` rejected with clear error.
- [x] `deck2video --help` still shows the regular argparse help.
- [ ] Verify Ctrl-C during a real Marp render leaves no orphan ffmpeg / Chromium processes (needs a real run).
- [ ] Verify GPU memory is released after a TTS run (needs a real run on a GPU host with `nvidia-smi` / `Activity Monitor`).