### PR TITLE
Add ElevenLabs TTS engine and make both engines optional

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ The pipeline is orchestrated by `__main__.py` and flows through four modules in 
 0. **detect.py** -- Auto-detects format (`"marp"` or `"slidev"`) by checking YAML frontmatter keys, directive comments, and Vue component syntax. Falls back to Marp. Skipped when `--format` is explicit.
 1. **marp_parser.py** / **slidev_parser.py** -- Splits markdown on `---` delimiters, extracts speaker notes from `<!-- -->` HTML comments into `Slide` dataclasses (index, body, notes). The Slidev parser additionally strips per-slide frontmatter and does not filter Marp-style directive comments.
 2. **marp_renderer.py** / **slidev_renderer.py** -- Calls marp-cli or Slidev CLI (via npx or global install) to produce one PNG per slide. Marp output: `slides.001`, `slides.002`, etc. (no extension). Slidev output: `slides.001.png`, `slides.002.png`, etc.
-3. **tts.py** -- Synthesizes each slide's notes with Chatterbox TTS. Long notes are split by sentence and each sentence is generated separately, then concatenated with `torch.cat` into one WAV per slide. Slides without notes get a silent WAV. An optional pronunciation mapping (JSON) applies case-insensitive text substitutions before synthesis to correct mispronounced terms.
+3. **tts.py** / **elevenlabs_tts.py** -- Synthesizes each slide's notes to one WAV per slide. The engine is chosen with `--tts-engine` (default `chatterbox`). The Chatterbox backend (`tts.py`) runs a local model: long notes are split by sentence and each sentence is generated separately, then concatenated with `torch.cat`. The ElevenLabs backend (`elevenlabs_tts.py`) calls the hosted API (one request per slide, requesting `pcm_24000` wrapped in a WAV header via `utils.write_pcm_wav`); it needs the `ELEVENLABS_API_KEY` env var and `--elevenlabs-voice-id`, and lazy-imports the `elevenlabs` SDK. Both backends produce identical `audio_NNN.wav` outputs and share the pronunciation/silent-slide/interactive helpers. Slides without notes get a silent WAV. `__main__._generate_audio` dispatches to the selected backend.
 4. **assembler.py** -- Creates per-slide MPEG-TS segments (image looped for audio duration) then concatenates into the final MP4 using ffmpeg's concat demuxer.
 
 **utils.py** provides shared helpers: ffmpeg/ffprobe checks, silent WAV generation, and audio duration queries.
@@ -73,7 +73,13 @@ The pipeline is orchestrated by `__main__.py` and flows through four modules in 
 
 ## System Dependencies
 
-Python 3.11, Node.js/npm (for marp-cli via npx), ffmpeg/ffprobe. The `setup.sh` script validates all of these, creates the venv, and installs Python packages. For Slidev support: `npm install -g @slidev/cli` and playwright-chromium (installed via `npx playwright install chromium`).
+Python 3.11, Node.js/npm (for marp-cli via npx), ffmpeg/ffprobe. The `setup.sh` script validates all of these, creates the venv, and installs the core Python packages (`requirements.txt`). For Slidev support: `npm install -g @slidev/cli` and playwright-chromium (installed via `npx playwright install chromium`).
+
+The two TTS engines are **optional** and split into separate requirements files so you install only what you use; `setup.sh` prompts you to pick at least one:
+- **Chatterbox** (default, `--tts-engine chatterbox`): `requirements-chatterbox.txt` — `chatterbox-tts`, `torch`, `torchaudio` (large download, runs locally). If the engine is selected but not installed, `tts.py` raises a `RuntimeError` pointing at `requirements-chatterbox.txt`.
+- **ElevenLabs** (`--tts-engine elevenlabs`): `requirements-elevenlabs.txt` — the small `elevenlabs` SDK, plus the `ELEVENLABS_API_KEY` environment variable at runtime. Missing-SDK runs raise a `RuntimeError` with a `pip install` hint.
+
+Both SDKs are lazy-imported, so importing the package or running the other engine never requires the one you didn't install.
 
 ## Tests
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ python -m deck2video presentation.md --voice voice-sample.wav
 ```
 
 The setup script checks for system dependencies, creates a Python 3.11 virtual
-environment, installs packages, and activates the venv in your shell.
+environment, installs the core packages, and activates the venv in your shell.
+It also prompts you to choose at least one TTS engine (see below) since both are
+optional installs.
 
 ## Documentation
 
@@ -36,6 +38,10 @@ Detailed guides covering every feature and workflow:
 - **Python 3.11**
 - **Node.js / npm** (for marp-cli via npx)
 - **ffmpeg**
+
+A TTS engine (at least one; `setup.sh` prompts you to pick):
+- **Chatterbox** (default, local model): `pip install -r requirements-chatterbox.txt` (large; pulls in torch)
+- **ElevenLabs** (hosted API): `pip install -r requirements-elevenlabs.txt`, plus an `ELEVENLABS_API_KEY` environment variable
 
 For Slidev presentations (optional):
 - **@slidev/cli** (`npm install -g @slidev/cli`)
@@ -144,7 +150,10 @@ python -m deck2video <input.md> [options]
 |------|---------|-------------|
 | `--format` | `auto` | Presentation format: `auto`, `marp`, or `slidev` |
 | `--output` | `<input>.mp4` | Output file path |
-| `--voice` | none | Reference WAV for voice cloning |
+| `--tts-engine` | `chatterbox` | TTS backend: `chatterbox` (local) or `elevenlabs` (hosted API) |
+| `--elevenlabs-voice-id` | none | ElevenLabs voice ID (required with `--tts-engine elevenlabs`) |
+| `--elevenlabs-model` | `eleven_multilingual_v2` | ElevenLabs model ID |
+| `--voice` | none | Reference WAV for Chatterbox voice cloning |
 | `--language` | none | Language code for multilingual TTS (e.g. `fr`, `zh`, `de`) |
 | `--device` | `auto` | Torch device: `auto`, `cpu`, `cuda`, `mps` |
 | `--exaggeration` | `0.5` | Chatterbox vocal exaggeration |
@@ -193,6 +202,12 @@ python -m deck2video deck.md \
 python -m deck2video deck.md \
     --voice ~/models/my-voice.wav \
     --pronunciations pronunciations.json
+
+# Use the ElevenLabs hosted API instead of the local Chatterbox model
+export ELEVENLABS_API_KEY=sk_...
+python -m deck2video deck.md \
+    --tts-engine elevenlabs \
+    --elevenlabs-voice-id 21m00Tcm4TlvDq8ikWAM
 
 # Explicit Slidev format
 python -m deck2video slidev-deck.md --format slidev --voice voice.wav

--- a/deck2video/__main__.py
+++ b/deck2video/__main__.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import argparse
 import json
 import logging
+import os
 import shutil
 import sys
 import tempfile
@@ -15,6 +16,7 @@ from pathlib import Path
 from . import process
 from .assembler import assemble_video
 from .detect import detect_format
+from .elevenlabs_tts import generate_audio_for_slides_elevenlabs
 from .marp_parser import parse_marp
 from .marp_renderer import render_slides
 from .models import expand_slides_to_steps
@@ -45,6 +47,7 @@ TTS_ONLY_FLAGS = {
     "--voice", "--device", "--exaggeration", "--cfg-weight",
     "--temperature", "--pronunciations", "--interactive", "-i",
     "--language", "--hold-duration",
+    "--tts-engine", "--elevenlabs-voice-id", "--elevenlabs-model",
 }
 
 
@@ -313,6 +316,45 @@ def _apply_audio_renames(
             logger.debug("Moved audio_%03d.wav.tmp → audio_%03d.wav", old_idx, new_idx)
 
 
+def _generate_audio(
+    steps: list,
+    *,
+    args,
+    temp_dir: Path,
+    pronunciations,
+    elevenlabs_api_key: str | None,
+) -> list[Path]:
+    """Dispatch TTS to the selected engine.
+
+    Both backends produce ``audio_NNN.wav`` files in ``temp_dir`` and return
+    the paths in step order, so every call site is engine-agnostic.
+    """
+    common = dict(
+        temp_dir=temp_dir,
+        hold_duration=args.hold_duration,
+        pronunciations=pronunciations,
+        interactive=args.interactive,
+    )
+    if args.tts_engine == "elevenlabs":
+        return generate_audio_for_slides_elevenlabs(
+            steps,
+            voice_id=args.elevenlabs_voice_id,
+            api_key=elevenlabs_api_key,
+            model_id=args.elevenlabs_model,
+            **common,
+        )
+    return generate_audio_for_slides(
+        steps,
+        voice_path=args.voice,
+        device=args.device,
+        exaggeration=args.exaggeration,
+        cfg_weight=args.cfg_weight,
+        temperature=args.temperature,
+        language=args.language,
+        **common,
+    )
+
+
 def _parse_slides(input_path: Path, fmt: str) -> list:
     """Parse slides using the appropriate parser for the detected format."""
     if fmt == "slidev":
@@ -365,6 +407,15 @@ def main() -> None:
     )
     parser.add_argument("input", help="Path to the Marp or Slidev .md file")
     parser.add_argument("--output", help="Output MP4 path (default: <input>.mp4)")
+    parser.add_argument("--tts-engine", choices=["chatterbox", "elevenlabs"], default="chatterbox",
+                        help="Text-to-speech engine: chatterbox (local model, default) or "
+                             "elevenlabs (hosted API; needs ELEVENLABS_API_KEY and "
+                             "--elevenlabs-voice-id)")
+    parser.add_argument("--elevenlabs-voice-id", default=None, metavar="ID",
+                        help="ElevenLabs voice ID to narrate with (required when "
+                             "--tts-engine elevenlabs)")
+    parser.add_argument("--elevenlabs-model", default="eleven_multilingual_v2", metavar="MODEL",
+                        help="ElevenLabs model ID (default: eleven_multilingual_v2)")
     parser.add_argument("--voice", help="Path to a reference WAV for Chatterbox voice cloning")
     parser.add_argument("--language", default=None, metavar="LANG",
                         help="Language code for multilingual TTS, e.g. en, fr, de, zh, es. "
@@ -451,6 +502,26 @@ def main() -> None:
         raw_pronunciations = load_pronunciations(pron_path)
         pronunciations = compile_pronunciations(raw_pronunciations)
         print(f"Loaded {len(raw_pronunciations)} pronunciation override(s)")
+
+    # Resolve and validate ElevenLabs configuration. Only required when the
+    # TTS phase will actually run (i.e. not --reassemble), and the API key
+    # comes from the environment so it never lands in shell history or logs.
+    elevenlabs_api_key = None
+    if args.tts_engine == "elevenlabs" and not args.reassemble:
+        elevenlabs_api_key = os.environ.get("ELEVENLABS_API_KEY")
+        if not elevenlabs_api_key:
+            print(
+                "Error: --tts-engine elevenlabs requires the ELEVENLABS_API_KEY "
+                "environment variable to be set.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
+        if not args.elevenlabs_voice_id:
+            print(
+                "Error: --tts-engine elevenlabs requires --elevenlabs-voice-id.",
+                file=sys.stderr,
+            )
+            sys.exit(1)
 
     # Pre-flight checks
     check_ffmpeg()
@@ -604,18 +675,12 @@ def main() -> None:
                     redo_steps = [s for s in all_steps if s.slide_index in slide_indices_set]
                     print(f"[redo] Regenerating audio for slide(s): {','.join(str(i) for i in slide_indices)}")
                     t0 = time.monotonic()
-                    generate_audio_for_slides(
+                    _generate_audio(
                         redo_steps,
+                        args=args,
                         temp_dir=temp_dir,
-                        voice_path=args.voice,
-                        device=args.device,
-                        exaggeration=args.exaggeration,
-                        cfg_weight=args.cfg_weight,
-                        temperature=args.temperature,
-                        hold_duration=args.hold_duration,
                         pronunciations=pronunciations,
-                        interactive=args.interactive,
-                        language=args.language,
+                        elevenlabs_api_key=elevenlabs_api_key,
                     )
                     logger.info("[redo] Audio regeneration completed in %.2fs", time.monotonic() - t0)
 
@@ -658,18 +723,12 @@ def main() -> None:
                 redo_steps = [s for s in all_steps if s.index in slide_indices_set]
             print(f"[redo] Regenerating audio for slide(s): {','.join(str(i) for i in slide_indices)}")
             t0 = time.monotonic()
-            generate_audio_for_slides(
+            _generate_audio(
                 redo_steps,
+                args=args,
                 temp_dir=temp_dir,
-                voice_path=args.voice,
-                device=args.device,
-                exaggeration=args.exaggeration,
-                cfg_weight=args.cfg_weight,
-                temperature=args.temperature,
-                hold_duration=args.hold_duration,
                 pronunciations=pronunciations,
-                interactive=args.interactive,
-                language=args.language,
+                elevenlabs_api_key=elevenlabs_api_key,
             )
             logger.info("[redo] Audio regeneration completed in %.2fs", time.monotonic() - t0)
 
@@ -749,18 +808,12 @@ def main() -> None:
             # Step 3: Generate audio
             print("[3/4] Generating audio…")
             t0 = time.monotonic()
-            audio_files = generate_audio_for_slides(
+            audio_files = _generate_audio(
                 steps,
+                args=args,
                 temp_dir=temp_dir,
-                voice_path=args.voice,
-                device=args.device,
-                exaggeration=args.exaggeration,
-                cfg_weight=args.cfg_weight,
-                temperature=args.temperature,
-                hold_duration=args.hold_duration,
                 pronunciations=pronunciations,
-                interactive=args.interactive,
-                language=args.language,
+                elevenlabs_api_key=elevenlabs_api_key,
             )
             logger.info("[3/4] Audio generation completed in %.2fs", time.monotonic() - t0)
 

--- a/deck2video/elevenlabs_tts.py
+++ b/deck2video/elevenlabs_tts.py
@@ -1,0 +1,138 @@
+"""ElevenLabs TTS backend — synthesises speaker notes to WAV files.
+
+A drop-in alternative to :mod:`deck2video.tts` (Chatterbox). Selected with
+``--tts-engine elevenlabs``. Where Chatterbox runs a local model on
+CPU/GPU, this calls the hosted ElevenLabs API: one request per slide,
+requesting raw ``pcm_24000`` audio that we wrap in a WAV header so the
+rest of the pipeline (ffprobe, the assembler) treats it identically to
+Chatterbox output.
+
+The heavy ``elevenlabs`` SDK is imported lazily inside
+:func:`generate_audio_for_slides_elevenlabs` so that nothing is required
+unless this backend is actually used.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from pathlib import Path
+
+# Reuse the shared helpers from the Chatterbox backend so behaviour (labels,
+# interactive prompts, pronunciation substitution) stays consistent across
+# engines.
+from .tts import _interactive_review, _label, apply_pronunciations
+from .utils import generate_silent_wav, write_pcm_wav
+
+logger = logging.getLogger(__name__)
+
+# ElevenLabs ``pcm_24000`` is signed 16-bit little-endian mono PCM, which
+# matches the WAV parameters our silent-WAV writer uses, so the assembled
+# audio stays at a single sample rate end-to-end.
+ELEVENLABS_SAMPLE_RATE = 24000
+ELEVENLABS_OUTPUT_FORMAT = "pcm_24000"
+
+DEFAULT_MODEL = "eleven_multilingual_v2"
+
+
+def _synthesize(client, *, text: str, voice_id: str, model_id: str) -> bytes:
+    """Call ElevenLabs text-to-speech and return raw PCM bytes.
+
+    ``client.text_to_speech.convert`` streams the audio back as an iterable
+    of byte chunks; we join them into a single buffer.
+    """
+    audio = client.text_to_speech.convert(
+        voice_id=voice_id,
+        text=text,
+        model_id=model_id,
+        output_format=ELEVENLABS_OUTPUT_FORMAT,
+    )
+    if isinstance(audio, bytes):
+        return audio
+    if isinstance(audio, bytearray):
+        return bytes(audio)
+    return b"".join(audio)
+
+
+def generate_audio_for_slides_elevenlabs(
+    slides,
+    *,
+    temp_dir: Path,
+    voice_id: str,
+    api_key: str,
+    model_id: str = DEFAULT_MODEL,
+    hold_duration: float,
+    pronunciations=None,
+    interactive: bool = False,
+) -> list[Path]:
+    """Generate a WAV file for every slide via the ElevenLabs API.
+
+    Mirrors :func:`deck2video.tts.generate_audio_for_slides`: slides with
+    speaker notes are synthesised; slides without notes get a silent WAV of
+    ``hold_duration`` seconds. On a per-slide API failure we log the error
+    and substitute silence so one bad slide doesn't abort the whole render.
+
+    Returns the list of audio paths in slide order.
+    """
+    try:
+        from elevenlabs.client import ElevenLabs
+    except ImportError as exc:
+        raise RuntimeError(
+            "The 'elevenlabs' package is required for --tts-engine elevenlabs. "
+            "Install it with: pip install elevenlabs"
+        ) from exc
+
+    client = ElevenLabs(api_key=api_key)
+    logger.debug("ElevenLabs client ready (model=%s, voice=%s)", model_id, voice_id)
+
+    audio_paths: list[Path] = []
+
+    for slide in slides:
+        out_path = temp_dir / f"audio_{slide.index:03d}.wav"
+
+        if slide.notes is None:
+            logger.debug("%s: no notes, generating %ss silence", _label(slide), hold_duration)
+            generate_silent_wav(out_path, hold_duration)
+            print(f"  {_label(slide)}: silent ({hold_duration}s)")
+            audio_paths.append(out_path)
+            continue
+
+        text = slide.notes
+        if pronunciations:
+            substituted = apply_pronunciations(text, pronunciations)
+            if substituted != text:
+                logger.debug("%s: after pronunciations=%r", _label(slide), substituted)
+            text = substituted
+
+        try:
+            pcm = _synthesize(client, text=text, voice_id=voice_id, model_id=model_id)
+        except Exception as exc:
+            msg = f"{_label(slide)}: ElevenLabs TTS failed ({exc}), substituting silence"
+            logger.error(msg, exc_info=True)
+            print(f"  {msg}", file=sys.stderr)
+            generate_silent_wav(out_path, hold_duration)
+            audio_paths.append(out_path)
+            continue
+
+        write_pcm_wav(out_path, pcm, sample_rate=ELEVENLABS_SAMPLE_RATE)
+        print(f"  {_label(slide)}: TTS OK ({len(text)} chars)")
+
+        if interactive:
+            def _regen() -> bool:
+                try:
+                    pcm = _synthesize(client, text=text, voice_id=voice_id, model_id=model_id)
+                except Exception as regen_exc:
+                    print(
+                        f"  Regeneration failed ({regen_exc}), keeping previous audio.",
+                        file=sys.stderr,
+                    )
+                    return False
+                write_pcm_wav(out_path, pcm, sample_rate=ELEVENLABS_SAMPLE_RATE)
+                print(f"  {_label(slide)}: TTS OK ({len(text)} chars)")
+                return True
+
+            _interactive_review(out_path, _label(slide), _regen)
+
+        audio_paths.append(out_path)
+
+    return audio_paths

--- a/deck2video/tts.py
+++ b/deck2video/tts.py
@@ -94,6 +94,37 @@ def _play_audio(path: Path) -> None:
     process.run(cmd, capture_output=True)
 
 
+def _interactive_review(out_path: Path, label: str, regenerate) -> None:
+    """Play the generated audio and let the user keep/regenerate/replay/quit.
+
+    ``regenerate`` is a zero-arg callable that re-synthesises and overwrites
+    ``out_path`` in place, returning ``True`` on success or ``False`` if it
+    failed (in which case the previous audio is kept). Shared by the
+    Chatterbox and ElevenLabs backends so the review UX stays identical.
+    """
+    _play_audio(out_path)
+    while True:
+        choice = input(
+            f"  {label}: (y) keep  (n) regenerate  (r) replay  (q) quit: "
+        ).strip().lower()
+        if choice in ("", "y"):
+            logger.debug("%s: interactive — kept", label)
+            break
+        if choice == "r":
+            _play_audio(out_path)
+            continue
+        if choice == "q":
+            logger.info("Pipeline quit by user during interactive review")
+            print("  Quitting pipeline.")
+            sys.exit(0)
+        # choice == "n" or anything else: regenerate
+        logger.debug("%s: interactive — regenerating", label)
+        print(f"  Regenerating {label}…")
+        if not regenerate():
+            break
+        _play_audio(out_path)
+
+
 def _label(item) -> str:
     """Return a human-readable label for a Slide or Step."""
     if hasattr(item, "slide_index"):
@@ -137,14 +168,32 @@ def _resolve_device(device: str) -> str:
     return "cpu"
 
 
+# Shared hint shown when the Chatterbox/torch stack isn't installed. The
+# engine is optional (see requirements-chatterbox.txt), so a missing import
+# should point the user at the fix rather than dumping a raw ModuleNotFoundError.
+_CHATTERBOX_MISSING_MSG = (
+    "The Chatterbox TTS engine requires torch, torchaudio, and chatterbox-tts. "
+    "Install them with: pip install -r requirements-chatterbox.txt "
+    "(or re-run setup.sh and choose Chatterbox). Alternatively, use "
+    "--tts-engine elevenlabs."
+)
+
+
 def _load_model(device: str = "auto", language: str | None = None):
     """Load ChatterboxTTS, or ChatterboxMultilingualTTS when language is set."""
-    import torchaudio  # noqa: F401 — ensure it's importable early
+    try:
+        import torch  # noqa: F401
+        import torchaudio  # noqa: F401 — ensure it's importable early
+    except ImportError as exc:
+        raise RuntimeError(_CHATTERBOX_MISSING_MSG) from exc
 
     resolved = _resolve_device(device)
     if language is not None:
         import torch
-        from chatterbox.mtl_tts import ChatterboxMultilingualTTS
+        try:
+            from chatterbox.mtl_tts import ChatterboxMultilingualTTS
+        except ImportError as exc:
+            raise RuntimeError(_CHATTERBOX_MISSING_MSG) from exc
         logger.debug("Loading ChatterboxMultilingualTTS on device=%s language=%s", resolved, language)
         print(f"  Loading multilingual TTS model (language: {language})")
         # ChatterboxMultilingualTTS.from_pretrained doesn't honour the device
@@ -161,7 +210,10 @@ def _load_model(device: str = "auto", language: str | None = None):
         finally:
             torch.load = _orig_load
     else:
-        from chatterbox.tts import ChatterboxTTS
+        try:
+            from chatterbox.tts import ChatterboxTTS
+        except ImportError as exc:
+            raise RuntimeError(_CHATTERBOX_MISSING_MSG) from exc
         logger.debug("Loading ChatterboxTTS on device=%s", resolved)
         model = ChatterboxTTS.from_pretrained(device=resolved)
     logger.debug("Model loaded successfully")
@@ -460,37 +512,24 @@ def _generate_audio_inner(
             print(f"  {_label(slide)}: TTS OK ({n_sent} sentence{'s' if n_sent != 1 else ''} in {n_chunks} chunk{'s' if n_chunks != 1 else ''})")
 
             if interactive:
-                _play_audio(out_path)
-                while True:
-                    choice = input(f"  {_label(slide)}: (y) keep  (n) regenerate  (r) replay  (q) quit: ").strip().lower()
-                    if choice in ("", "y"):
-                        logger.debug("%s: interactive — kept", _label(slide))
-                        break
-                    if choice == "r":
-                        _play_audio(out_path)
-                        continue
-                    if choice == "q":
-                        logger.info("Pipeline quit by user during interactive review")
-                        print("  Quitting pipeline.")
-                        sys.exit(0)
-                    # choice == "n" or anything else: regenerate
-                    # Note: regen currently uses the same deterministic seed,
-                    # so output will be identical. Per-regen seed bumping is
-                    # tracked as a follow-up (B34 in ROADMAP.md).
-                    logger.debug("%s: interactive — regenerating", _label(slide))
-                    print(f"  Regenerating {_label(slide)}…")
+                # Note: regen currently uses the same deterministic seed, so
+                # output will be identical. Per-regen seed bumping is tracked
+                # as a follow-up (B34 in ROADMAP.md).
+                def _regen() -> bool:
                     try:
                         combined, sr, n_sent, n_chunks = _generate_slide_audio(
                             model, slide, text, **tts_kwargs,
                         )
                     except Exception as regen_exc:
                         print(f"  Regeneration failed ({regen_exc}), keeping previous audio.", file=sys.stderr)
-                        break
+                        return False
                     torchaudio.save(str(out_path), combined, sr)
                     del combined
                     _flush_gpu()
                     print(f"  {_label(slide)}: TTS OK ({n_sent} sentence{'s' if n_sent != 1 else ''} in {n_chunks} chunk{'s' if n_chunks != 1 else ''})")
-                    _play_audio(out_path)
+                    return True
+
+                _interactive_review(out_path, _label(slide), _regen)
 
         audio_paths.append(out_path)
 

--- a/deck2video/utils.py
+++ b/deck2video/utils.py
@@ -37,13 +37,22 @@ def check_ffmpeg() -> None:
         sys.exit(1)
 
 
-def generate_silent_wav(path: Path, duration: float, sample_rate: int = 24000) -> None:
-    """Write a silent WAV file of the given duration (pure Python, no deps)."""
-    num_channels = 1
-    bits_per_sample = 16
-    num_samples = int(sample_rate * duration)
-    data_size = num_samples * num_channels * (bits_per_sample // 8)
+def write_pcm_wav(
+    path: Path,
+    pcm: bytes,
+    *,
+    sample_rate: int = 24000,
+    num_channels: int = 1,
+    bits_per_sample: int = 16,
+) -> None:
+    """Wrap raw little-endian PCM bytes in a WAV container (pure Python, no deps).
 
+    Used both for silent WAVs (all-zero ``pcm``) and for ElevenLabs ``pcm_*``
+    output, which is signed 16-bit little-endian mono and so needs only a
+    RIFF/WAVE header prepended to be a valid file the rest of the pipeline
+    can probe and assemble.
+    """
+    data_size = len(pcm)
     with open(path, "wb") as f:
         # RIFF header
         f.write(b"RIFF")
@@ -61,7 +70,22 @@ def generate_silent_wav(path: Path, duration: float, sample_rate: int = 24000) -
         # data chunk
         f.write(b"data")
         f.write(struct.pack("<I", data_size))
-        f.write(b"\x00" * data_size)
+        f.write(pcm)
+
+
+def generate_silent_wav(path: Path, duration: float, sample_rate: int = 24000) -> None:
+    """Write a silent WAV file of the given duration (pure Python, no deps)."""
+    num_channels = 1
+    bits_per_sample = 16
+    num_samples = int(sample_rate * duration)
+    data_size = num_samples * num_channels * (bits_per_sample // 8)
+    write_pcm_wav(
+        path,
+        b"\x00" * data_size,
+        sample_rate=sample_rate,
+        num_channels=num_channels,
+        bits_per_sample=bits_per_sample,
+    )
 
 
 def _wav_duration_from_header(path: Path) -> float | None:

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -86,6 +86,35 @@ Preserve intermediate files after a successful run.
 
 ## TTS options
 
+### `--tts-engine`
+
+Which text-to-speech backend to use.
+
+- **Type:** choice
+- **Choices:** `chatterbox`, `elevenlabs`
+- **Default:** `chatterbox`
+- **Details:** `chatterbox` runs a local neural model (CPU/GPU). `elevenlabs` calls the hosted [ElevenLabs](https://elevenlabs.io) API: it requires the `ELEVENLABS_API_KEY` environment variable and `--elevenlabs-voice-id`. The Chatterbox-only flags (`--voice`, `--device`, `--exaggeration`, `--cfg-weight`, `--temperature`, `--language`) have no effect when the ElevenLabs engine is selected. See [Voice and TTS](voice-and-tts.md#tts-engines).
+- **Example:** `--tts-engine elevenlabs`
+
+### `--elevenlabs-voice-id`
+
+ElevenLabs voice ID to narrate with.
+
+- **Type:** string
+- **Default:** none
+- **Required:** when `--tts-engine elevenlabs`
+- **Details:** Find voice IDs in your ElevenLabs voice library. The API key is read from the `ELEVENLABS_API_KEY` environment variable (never a flag, so it stays out of shell history).
+- **Example:** `--elevenlabs-voice-id 21m00Tcm4TlvDq8ikWAM`
+
+### `--elevenlabs-model`
+
+ElevenLabs model ID.
+
+- **Type:** string
+- **Default:** `eleven_multilingual_v2`
+- **Details:** Other common options: `eleven_turbo_v2_5` (faster/cheaper), `eleven_flash_v2_5` (lowest latency). Only used when `--tts-engine elevenlabs`.
+- **Example:** `--elevenlabs-model eleven_turbo_v2_5`
+
 ### `--voice`
 
 Path to a reference WAV file for Chatterbox voice cloning.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -48,7 +48,7 @@ npx playwright install chromium
 
 ## Running setup.sh
 
-`setup.sh` checks for system dependencies, creates a Python 3.11 virtual environment, installs packages, and activates the venv in your current shell. It also asks whether you want to install Slidev support (the Slidev CLI and Playwright Chromium).
+`setup.sh` checks for system dependencies, creates a Python 3.11 virtual environment, installs the core packages, and activates the venv in your current shell. It also asks whether you want to install Slidev support (the Slidev CLI and Playwright Chromium), and prompts you to choose at least one TTS engine (Chatterbox, ElevenLabs, or both), since both are optional installs.
 
 You must source the script, not execute it:
 
@@ -67,10 +67,12 @@ What the script does:
 
 1. Checks that `python3.11`, `ffmpeg`, `ffprobe`, and `npx` (or `marp`) are on PATH.
 2. Asks if you want Slidev support (skipped if `slidev` is already installed).
-3. Creates `.venv/` if it doesn't exist (or recreates it if the existing one is broken).
-4. Installs/upgrades pip and all packages from `requirements.txt`.
-5. If you said yes to Slidev: installs `@slidev/cli`, the `playwright-chromium` npm package, and the Chromium browser binary.
-6. Activates the virtual environment.
+3. Prompts you to choose at least one TTS engine (Chatterbox, ElevenLabs, or both).
+4. Creates `.venv/` if it doesn't exist (or recreates it if the existing one is broken).
+5. Installs/upgrades pip and the core packages from `requirements.txt`.
+6. Installs the TTS engine(s) you chose: `requirements-chatterbox.txt` (large; torch) and/or `requirements-elevenlabs.txt`.
+7. If you said yes to Slidev: installs `@slidev/cli`, the `playwright-chromium` npm package, and the Chromium browser binary.
+8. Activates the virtual environment.
 
 After setup completes, you can run deck2video directly:
 

--- a/docs/voice-and-tts.md
+++ b/docs/voice-and-tts.md
@@ -1,8 +1,36 @@
 # Voice and TTS
 
-deck2video uses [Chatterbox TTS](https://github.com/resemble-ai/chatterbox) for speech synthesis. Chatterbox is a neural TTS model that supports zero-shot voice cloning from a short audio sample. deck2video loads the model once and synthesizes all slides sequentially.
+deck2video uses [Chatterbox TTS](https://github.com/resemble-ai/chatterbox) for speech synthesis by default. Chatterbox is a neural TTS model that supports zero-shot voice cloning from a short audio sample. deck2video loads the model once and synthesizes all slides sequentially.
 
 The model and its dependencies (torch, torchaudio, chatterbox) are lazy-loaded. They're only imported when at least one slide has speaker notes. If your deck has no notes at all, the TTS model is never loaded.
+
+## TTS engines
+
+Both engines are **optional** and installed separately, so you only pull in what you use. `setup.sh` prompts you to pick at least one; you can also install them by hand (see the Setup column). Pick a backend at runtime with `--tts-engine`:
+
+| Engine | Where it runs | Voice selection | Install |
+|--------|---------------|-----------------|---------|
+| `chatterbox` (default) | Local model (CPU/GPU) | `--voice` reference WAV (optional) | `pip install -r requirements-chatterbox.txt` (large; torch) |
+| `elevenlabs` | Hosted [ElevenLabs](https://elevenlabs.io) API | `--elevenlabs-voice-id` (required) | `pip install -r requirements-elevenlabs.txt` + `ELEVENLABS_API_KEY` env var |
+
+If you select an engine whose dependencies aren't installed, deck2video exits with a clear error pointing at the right requirements file (for Chatterbox) or `pip install` hint (for ElevenLabs) rather than a raw traceback.
+
+### ElevenLabs
+
+```bash
+export ELEVENLABS_API_KEY=sk_...
+python -m deck2video deck.md \
+    --tts-engine elevenlabs \
+    --elevenlabs-voice-id 21m00Tcm4TlvDq8ikWAM
+```
+
+The API key is read from the `ELEVENLABS_API_KEY` environment variable, never a flag, so it stays out of shell history and the log file. The voice ID comes from your ElevenLabs voice library. The model defaults to `eleven_multilingual_v2`; override it with `--elevenlabs-model` (e.g. `eleven_turbo_v2_5` for faster/cheaper synthesis, `eleven_flash_v2_5` for lowest latency).
+
+deck2video requests raw `pcm_24000` audio and wraps it in a WAV container, so ElevenLabs output flows through the rest of the pipeline (probing, padding, assembly) identically to Chatterbox output. One API request is made per slide that has speaker notes; slides without notes still get a local silent WAV with no API call. If a request fails, that slide falls back to silence and the render continues.
+
+The `elevenlabs` Python SDK is an optional dependency: it lives in `requirements-elevenlabs.txt` (not the core `requirements.txt`) and is lazy-imported, so a Chatterbox-only install never needs it. Install it by answering "y" to the ElevenLabs prompt in `setup.sh`, or directly with `pip install -r requirements-elevenlabs.txt`. If you select `--tts-engine elevenlabs` without the SDK installed, deck2video exits with a clear "pip install elevenlabs" hint. `--pronunciations` and `--interactive` work with both engines. The Chatterbox-only flags (`--voice`, `--device`, `--exaggeration`, `--cfg-weight`, `--temperature`, `--language`) have no effect under the ElevenLabs engine.
+
+The rest of this page describes the Chatterbox engine.
 
 ## Voice cloning
 

--- a/requirements-chatterbox.txt
+++ b/requirements-chatterbox.txt
@@ -1,0 +1,10 @@
+# Chatterbox TTS engine (the default; --tts-engine chatterbox). This is a large
+# install: torch plus the model dependencies. Optional — install only if you
+# want local, offline speech synthesis with voice cloning.
+#
+# Install with: pip install -r requirements-chatterbox.txt
+#
+# Pinned to last-tested versions. To refresh: bump, run setup.sh, run tests, commit.
+chatterbox-tts==0.1.6
+torch==2.6.0
+torchaudio==2.6.0

--- a/requirements-elevenlabs.txt
+++ b/requirements-elevenlabs.txt
@@ -1,0 +1,8 @@
+# Optional dependency for the ElevenLabs TTS backend (--tts-engine elevenlabs).
+# Not needed for the default Chatterbox engine; the SDK is lazy-imported so it's
+# only required when you actually select the ElevenLabs engine.
+#
+# Install with: pip install -r requirements-elevenlabs.txt
+#
+# Pinned to last-tested version. To refresh: bump, run setup.sh, run tests, commit.
+elevenlabs==2.54.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
-# Pinned to last-tested versions for reproducible installs.
-# To refresh: bump these numbers, run setup.sh, run tests, commit.
-chatterbox-tts==0.1.6
-torch==2.6.0
-torchaudio==2.6.0
+# Core dependencies for deck2video. Pinned to last-tested versions for
+# reproducible installs. To refresh: bump, run setup.sh, run tests, commit.
+#
+# The TTS engines are optional and split into their own files so you install
+# only what you use. setup.sh prompts you to pick at least one:
+#   - requirements-chatterbox.txt  — local Chatterbox model (large; torch)
+#   - requirements-elevenlabs.txt  — hosted ElevenLabs API (small SDK)
 python-frontmatter==1.1.0

--- a/setup.sh
+++ b/setup.sh
@@ -98,6 +98,37 @@ else
     fi
 fi
 
+# ── TTS engine selection (at least one required) ────────────────────────────
+#
+# Both engines are optional and heavy in different ways: Chatterbox pulls in
+# torch (a large download) but runs locally; ElevenLabs is a tiny SDK but calls
+# a paid hosted API. deck2video needs at least one, so loop until the user
+# picks something rather than leaving them with a tool that can't synthesize.
+
+INSTALL_CHATTERBOX=false
+INSTALL_ELEVENLABS=false
+
+while true; do
+    INSTALL_CHATTERBOX=false
+    INSTALL_ELEVENLABS=false
+
+    echo ""
+    echo "Choose at least one TTS engine:"
+
+    printf "  Install Chatterbox? (local neural model, default engine, large download) [y/N] "
+    read -r answer
+    [[ "$answer" =~ ^[Yy]$ ]] && INSTALL_CHATTERBOX=true
+
+    printf "  Install ElevenLabs? (hosted API, small SDK, needs ELEVENLABS_API_KEY) [y/N] "
+    read -r answer
+    [[ "$answer" =~ ^[Yy]$ ]] && INSTALL_ELEVENLABS=true
+
+    if $INSTALL_CHATTERBOX || $INSTALL_ELEVENLABS; then
+        break
+    fi
+    warn "deck2video needs a TTS engine. Pick Chatterbox, ElevenLabs, or both."
+done
+
 # ── Virtual environment ─────────────────────────────────────────────────────
 
 echo ""
@@ -124,7 +155,21 @@ echo "Installing Python dependencies (this may take a while on first run)…"
 
 "$PIP" install --upgrade pip --quiet
 "$PIP" install -r requirements.txt --quiet
-info "All packages installed"
+info "Core packages installed"
+
+if $INSTALL_CHATTERBOX; then
+    echo ""
+    echo "Installing Chatterbox TTS (this downloads torch and may take a while)…"
+    "$PIP" install -r requirements-chatterbox.txt --quiet
+    info "Chatterbox TTS installed"
+fi
+
+if $INSTALL_ELEVENLABS; then
+    echo ""
+    echo "Installing ElevenLabs TTS support…"
+    "$PIP" install -r requirements-elevenlabs.txt --quiet
+    info "ElevenLabs SDK installed"
+fi
 
 # ── Slidev installation ───────────────────────────────────────────────────────
 
@@ -158,7 +203,13 @@ info "Activated $VENV_DIR"
 
 echo ""
 echo "Setup complete. You're ready to go:"
-echo "  python -m deck2video presentation.md --voice path/to/voice.wav"
+if $INSTALL_CHATTERBOX; then
+    echo "  python -m deck2video presentation.md --voice path/to/voice.wav"
+fi
+if $INSTALL_ELEVENLABS; then
+    echo "  export ELEVENLABS_API_KEY=sk_..."
+    echo "  python -m deck2video presentation.md --tts-engine elevenlabs --elevenlabs-voice-id <id>"
+fi
 echo ""
 
 # Restore the caller's prior shell options so sourcing this script doesn't

--- a/tests/test_elevenlabs_tts.py
+++ b/tests/test_elevenlabs_tts.py
@@ -1,0 +1,274 @@
+"""Tests for deck2video.elevenlabs_tts — ElevenLabs API TTS backend.
+
+The ``elevenlabs`` SDK is mocked via ``sys.modules`` so these tests run
+without the package installed and without making any network calls.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from deck2video.elevenlabs_tts import generate_audio_for_slides_elevenlabs
+from deck2video.tts import compile_pronunciations
+
+
+def _make_slide(index, notes=None, video=None):
+    from deck2video.models import Slide
+    return Slide(index=index, body="body", notes=notes, video=video)
+
+
+def _fake_sdk(convert_side_effect):
+    """Build fake elevenlabs modules + return (sys.modules dict, client mock)."""
+    client_instance = MagicMock()
+    client_instance.text_to_speech.convert.side_effect = convert_side_effect
+    client_cls = MagicMock(return_value=client_instance)
+
+    client_mod = MagicMock()
+    client_mod.ElevenLabs = client_cls
+    pkg = MagicMock()
+
+    modules = {"elevenlabs": pkg, "elevenlabs.client": client_mod}
+    return modules, client_instance, client_cls
+
+
+def _run(slides, tmp_path, *, convert, **kwargs):
+    modules, client_instance, client_cls = _fake_sdk(convert)
+    with patch.dict("sys.modules", modules):
+        paths = generate_audio_for_slides_elevenlabs(
+            slides,
+            temp_dir=tmp_path,
+            voice_id=kwargs.pop("voice_id", "voice123"),
+            api_key=kwargs.pop("api_key", "key-abc"),
+            **kwargs,
+        )
+    return paths, client_instance, client_cls
+
+
+# ---------------------------------------------------------------------------
+# Basic synthesis
+# ---------------------------------------------------------------------------
+
+class TestSynthesis:
+    def test_notes_slide_writes_valid_wav(self, tmp_path):
+        slides = [_make_slide(1, notes="Hello world.")]
+        pcm = b"\x01\x02\x03\x04" * 100
+
+        paths, _, _ = _run(
+            slides, tmp_path,
+            convert=lambda **kw: iter([pcm]),
+            hold_duration=2.0,
+        )
+
+        assert len(paths) == 1
+        assert paths[0].name == "audio_001.wav"
+        data = paths[0].read_bytes()
+        assert data[:4] == b"RIFF"
+        assert data[8:12] == b"WAVE"
+        # PCM payload should be present after the 44-byte header.
+        assert data[44:] == pcm
+
+    def test_convert_called_with_expected_args(self, tmp_path):
+        slides = [_make_slide(1, notes="Hello.")]
+        _, client, _ = _run(
+            slides, tmp_path,
+            convert=lambda **kw: iter([b"\x00\x00"]),
+            hold_duration=2.0,
+            voice_id="my-voice",
+            model_id="eleven_turbo_v2_5",
+        )
+
+        kwargs = client.text_to_speech.convert.call_args.kwargs
+        assert kwargs["voice_id"] == "my-voice"
+        assert kwargs["text"] == "Hello."
+        assert kwargs["model_id"] == "eleven_turbo_v2_5"
+        assert kwargs["output_format"] == "pcm_24000"
+
+    def test_api_key_passed_to_client(self, tmp_path):
+        slides = [_make_slide(1, notes="Hi.")]
+        _, _, client_cls = _run(
+            slides, tmp_path,
+            convert=lambda **kw: iter([b"\x00\x00"]),
+            hold_duration=2.0,
+            api_key="secret-key",
+        )
+        assert client_cls.call_args.kwargs["api_key"] == "secret-key"
+
+    def test_convert_returning_raw_bytes_handled(self, tmp_path):
+        """convert() may return bytes directly rather than an iterator."""
+        slides = [_make_slide(1, notes="Hi.")]
+        pcm = b"\xaa\xbb" * 50
+        paths, _, _ = _run(
+            slides, tmp_path,
+            convert=lambda **kw: pcm,
+            hold_duration=2.0,
+        )
+        assert paths[0].read_bytes()[44:] == pcm
+
+
+# ---------------------------------------------------------------------------
+# Silent slides
+# ---------------------------------------------------------------------------
+
+class TestSilentSlides:
+    def test_slide_without_notes_gets_silence_no_api_call(self, tmp_path):
+        slides = [_make_slide(1, notes=None)]
+        paths, client, _ = _run(
+            slides, tmp_path,
+            convert=lambda **kw: iter([b"\x00"]),
+            hold_duration=2.0,
+        )
+
+        assert paths[0].read_bytes()[:4] == b"RIFF"
+        client.text_to_speech.convert.assert_not_called()
+
+    def test_mixed_slides(self, tmp_path):
+        slides = [_make_slide(1, notes="Talk."), _make_slide(2, notes=None)]
+        paths, client, _ = _run(
+            slides, tmp_path,
+            convert=lambda **kw: iter([b"\x01\x02"]),
+            hold_duration=1.5,
+        )
+        assert [p.name for p in paths] == ["audio_001.wav", "audio_002.wav"]
+        # Only the slide with notes hits the API.
+        assert client.text_to_speech.convert.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# Pronunciations
+# ---------------------------------------------------------------------------
+
+class TestPronunciations:
+    def test_pronunciations_applied_before_synthesis(self, tmp_path):
+        slides = [_make_slide(1, notes="Use kubectl now.")]
+        patterns = compile_pronunciations({"kubectl": "cube control"})
+
+        _, client, _ = _run(
+            slides, tmp_path,
+            convert=lambda **kw: iter([b"\x00\x00"]),
+            hold_duration=2.0,
+            pronunciations=patterns,
+        )
+        sent_text = client.text_to_speech.convert.call_args.kwargs["text"]
+        assert sent_text == "Use cube control now."
+
+    def test_notes_not_mutated(self, tmp_path):
+        slide = _make_slide(1, notes="Run kubectl.")
+        patterns = compile_pronunciations({"kubectl": "cube control"})
+        _run(
+            [slide], tmp_path,
+            convert=lambda **kw: iter([b"\x00\x00"]),
+            hold_duration=2.0,
+            pronunciations=patterns,
+        )
+        assert slide.notes == "Run kubectl."
+
+
+# ---------------------------------------------------------------------------
+# Failure handling
+# ---------------------------------------------------------------------------
+
+class TestFailureHandling:
+    def test_api_failure_substitutes_silence(self, tmp_path):
+        slides = [_make_slide(1, notes="This breaks.")]
+
+        def boom(**kw):
+            raise RuntimeError("network exploded")
+
+        paths, _, _ = _run(
+            slides, tmp_path,
+            convert=boom,
+            hold_duration=3.0,
+        )
+        assert len(paths) == 1
+        # Silent WAV fallback is still a valid RIFF file.
+        assert paths[0].read_bytes()[:4] == b"RIFF"
+
+    def test_missing_sdk_raises_helpful_error(self, tmp_path):
+        slides = [_make_slide(1, notes="Hi.")]
+        # Setting the module entries to None makes `import elevenlabs.client`
+        # raise ImportError.
+        with patch.dict("sys.modules", {"elevenlabs": None, "elevenlabs.client": None}):
+            with pytest.raises(RuntimeError, match="pip install elevenlabs"):
+                generate_audio_for_slides_elevenlabs(
+                    slides,
+                    temp_dir=tmp_path,
+                    voice_id="v",
+                    api_key="k",
+                    hold_duration=2.0,
+                )
+
+    def test_one_failure_does_not_abort_others(self, tmp_path):
+        slides = [_make_slide(1, notes="ok"), _make_slide(2, notes="boom")]
+
+        calls = {"n": 0}
+
+        def convert(**kw):
+            calls["n"] += 1
+            if kw["text"] == "boom":
+                raise RuntimeError("fail")
+            return iter([b"\x01\x02"])
+
+        paths, _, _ = _run(slides, tmp_path, convert=convert, hold_duration=2.0)
+        assert len(paths) == 2
+        assert all(p.read_bytes()[:4] == b"RIFF" for p in paths)
+
+
+# ---------------------------------------------------------------------------
+# Interactive mode
+# ---------------------------------------------------------------------------
+
+class TestInteractive:
+    def test_accept_keeps_audio(self, tmp_path):
+        slides = [_make_slide(1, notes="Hello.")]
+        with patch("deck2video.tts._play_audio") as mock_play, \
+             patch("builtins.input", return_value="y"):
+            paths, client, _ = _run(
+                slides, tmp_path,
+                convert=lambda **kw: iter([b"\x01\x02"]),
+                hold_duration=2.0,
+                interactive=True,
+            )
+        assert len(paths) == 1
+        mock_play.assert_called_once()
+        assert client.text_to_speech.convert.call_count == 1
+
+    def test_regenerate_then_accept(self, tmp_path):
+        slides = [_make_slide(1, notes="Hello.")]
+        with patch("deck2video.tts._play_audio") as mock_play, \
+             patch("builtins.input", side_effect=["n", "y"]):
+            _, client, _ = _run(
+                slides, tmp_path,
+                convert=lambda **kw: iter([b"\x01\x02"]),
+                hold_duration=2.0,
+                interactive=True,
+            )
+        # Original + one regeneration.
+        assert client.text_to_speech.convert.call_count == 2
+        assert mock_play.call_count == 2
+
+    def test_quit_exits(self, tmp_path):
+        slides = [_make_slide(1, notes="Hello.")]
+        with patch("deck2video.tts._play_audio"), \
+             patch("builtins.input", return_value="q"):
+            with pytest.raises(SystemExit):
+                _run(
+                    slides, tmp_path,
+                    convert=lambda **kw: iter([b"\x01\x02"]),
+                    hold_duration=2.0,
+                    interactive=True,
+                )
+
+    def test_silent_slide_skips_interactive(self, tmp_path):
+        slides = [_make_slide(1, notes=None)]
+        with patch("deck2video.tts._play_audio") as mock_play, \
+             patch("builtins.input") as mock_input:
+            _run(
+                slides, tmp_path,
+                convert=lambda **kw: iter([b"\x01"]),
+                hold_duration=2.0,
+                interactive=True,
+            )
+        mock_play.assert_not_called()
+        mock_input.assert_not_called()

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1567,3 +1567,116 @@ class TestRedoSlidesClickChange:
         # Manifest should now exist (written by redo path)
         assert (temp / "steps.json").exists()
 
+
+# ---------------------------------------------------------------------------
+# --tts-engine elevenlabs routing and validation
+# ---------------------------------------------------------------------------
+
+class TestElevenLabsEngine:
+    def _run_main(self, argv, patches):
+        import contextlib
+        from deck2video.__main__ import main
+
+        with patch("sys.argv", argv):
+            with contextlib.ExitStack() as stack:
+                mocks = {}
+                for target, mock_obj in patches.items():
+                    mocks[target] = stack.enter_context(patch(target, mock_obj))
+                main()
+                return mocks
+
+    def test_engine_routes_to_elevenlabs_backend(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "test-key")
+        md = tmp_path / "deck.md"
+        md.write_text("---\nmarp: true\n---\n\n# Slide\n")
+
+        patches = _patch_pipeline(**{
+            "deck2video.__main__.generate_audio_for_slides_elevenlabs": MagicMock(return_value=[
+                Path("/tmp/audio_001.wav"), Path("/tmp/audio_002.wav"),
+            ]),
+        })
+        mocks = self._run_main(
+            ["deck2video", str(md), "--tts-engine", "elevenlabs",
+             "--elevenlabs-voice-id", "voice123"],
+            patches,
+        )
+
+        # ElevenLabs backend used; Chatterbox backend untouched.
+        mocks["deck2video.__main__.generate_audio_for_slides_elevenlabs"].assert_called_once()
+        mocks["deck2video.__main__.generate_audio_for_slides"].assert_not_called()
+
+        gen = mocks["deck2video.__main__.generate_audio_for_slides_elevenlabs"]
+        assert gen.call_args.kwargs["voice_id"] == "voice123"
+        assert gen.call_args.kwargs["api_key"] == "test-key"
+        assert gen.call_args.kwargs["model_id"] == "eleven_multilingual_v2"
+
+    def test_custom_model_passed_through(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "k")
+        md = tmp_path / "deck.md"
+        md.write_text("---\nmarp: true\n---\n\n# Slide\n")
+
+        patches = _patch_pipeline(**{
+            "deck2video.__main__.generate_audio_for_slides_elevenlabs": MagicMock(return_value=[
+                Path("/tmp/audio_001.wav"), Path("/tmp/audio_002.wav"),
+            ]),
+        })
+        mocks = self._run_main(
+            ["deck2video", str(md), "--tts-engine", "elevenlabs",
+             "--elevenlabs-voice-id", "v", "--elevenlabs-model", "eleven_flash_v2_5"],
+            patches,
+        )
+        gen = mocks["deck2video.__main__.generate_audio_for_slides_elevenlabs"]
+        assert gen.call_args.kwargs["model_id"] == "eleven_flash_v2_5"
+
+    def test_missing_api_key_exits(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+        md = tmp_path / "deck.md"
+        md.write_text("# Slide\n")
+        from deck2video.__main__ import main
+        with patch("deck2video.__main__.check_ffmpeg"):
+            with patch("sys.argv", ["deck2video", str(md), "--tts-engine", "elevenlabs",
+                                    "--elevenlabs-voice-id", "v"]):
+                with pytest.raises(SystemExit):
+                    main()
+        assert "ELEVENLABS_API_KEY" in capsys.readouterr().err
+
+    def test_missing_voice_id_exits(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("ELEVENLABS_API_KEY", "k")
+        md = tmp_path / "deck.md"
+        md.write_text("# Slide\n")
+        from deck2video.__main__ import main
+        with patch("deck2video.__main__.check_ffmpeg"):
+            with patch("sys.argv", ["deck2video", str(md), "--tts-engine", "elevenlabs"]):
+                with pytest.raises(SystemExit):
+                    main()
+        assert "elevenlabs-voice-id" in capsys.readouterr().err
+
+    def test_default_engine_is_chatterbox(self, tmp_path):
+        md = tmp_path / "deck.md"
+        md.write_text("---\nmarp: true\n---\n\n# Slide\n")
+        patches = _patch_pipeline(**{
+            "deck2video.__main__.generate_audio_for_slides_elevenlabs": MagicMock(),
+        })
+        mocks = self._run_main(["deck2video", str(md)], patches)
+        mocks["deck2video.__main__.generate_audio_for_slides"].assert_called_once()
+        mocks["deck2video.__main__.generate_audio_for_slides_elevenlabs"].assert_not_called()
+
+    def test_reassemble_skips_elevenlabs_validation(self, tmp_path, monkeypatch):
+        """--reassemble must not require ELEVENLABS_API_KEY (TTS phase is skipped)."""
+        monkeypatch.delenv("ELEVENLABS_API_KEY", raising=False)
+        md = tmp_path / "deck.md"
+        md.write_text("---\nmarp: true\n---\n\n# Slide\n")
+        temp = tmp_path / "build"
+        temp.mkdir()
+        for i in range(1, 3):
+            (temp / f"slides.{i:03d}.png").touch()
+            (temp / f"audio_{i:03d}.wav").touch()
+
+        patches = _patch_pipeline()
+        # Should not raise despite engine=elevenlabs and no API key.
+        self._run_main(
+            ["deck2video", str(md), "--reassemble", "--temp-dir", str(temp),
+             "--tts-engine", "elevenlabs"],
+            patches,
+        )
+

--- a/tests/test_tts.py
+++ b/tests/test_tts.py
@@ -536,6 +536,33 @@ class TestInteractiveMode:
 # _load_model
 # ---------------------------------------------------------------------------
 
+class TestChatterboxMissing:
+    """The Chatterbox engine is an optional install; a missing stack should
+    raise a helpful error pointing at requirements-chatterbox.txt rather than a
+    raw ModuleNotFoundError."""
+
+    def test_missing_torch_raises_helpful_error(self):
+        from deck2video.tts import _load_model
+        # Mapping a module to None makes `import <name>` raise ImportError.
+        with patch.dict("sys.modules", {"torch": None, "torchaudio": None}):
+            with pytest.raises(RuntimeError, match="requirements-chatterbox.txt"):
+                _load_model("cpu")
+
+    def test_missing_chatterbox_raises_helpful_error(self):
+        from deck2video.tts import _load_model
+        mock_torch = MagicMock()
+        mock_torch.cuda.is_available.return_value = False
+        mock_torch.backends.mps.is_available.return_value = False
+        with patch.dict("sys.modules", {
+            "torch": mock_torch,
+            "torchaudio": MagicMock(),
+            "chatterbox": None,
+            "chatterbox.tts": None,
+        }):
+            with pytest.raises(RuntimeError, match="requirements-chatterbox.txt"):
+                _load_model("cpu")
+
+
 class TestLoadModel:
     def test_load_model_calls_from_pretrained(self):
         from deck2video.tts import _load_model


### PR DESCRIPTION
Adds a hosted ElevenLabs backend selectable with `--tts-engine elevenlabs`, alongside the existing local Chatterbox engine (still the default). The TTS phase is the only thing that changes: both backends write identical `audio_NNN.wav` files, so reassemble, redo-slides, padding, and FPS all keep working unchanged.

## ElevenLabs backend
- New flags `--elevenlabs-voice-id` and `--elevenlabs-model` (default `eleven_multilingual_v2`). The API key comes from the `ELEVENLABS_API_KEY` environment variable so it stays out of shell history and the log file.
- Requests raw `pcm_24000` audio and wraps it in a WAV header via a new `utils.write_pcm_wav` helper (`generate_silent_wav` now delegates to it).
- One API request per slide with notes; a failure falls back to silence so one bad slide does not abort the render. The `elevenlabs` SDK is lazy-imported.
- `__main__._generate_audio` dispatches to the selected backend. The shared interactive review loop now lives in `tts._interactive_review` and is reused by both engines.

## Both engines are now optional
- Split the heavy Chatterbox stack (`chatterbox-tts`, `torch`, `torchaudio`) into `requirements-chatterbox.txt` and the ElevenLabs SDK into `requirements-elevenlabs.txt`. `requirements.txt` keeps only the lean core.
- `setup.sh` prompts the user to choose at least one engine and installs only what they pick.
- Selecting an engine whose dependencies are missing raises a clear `RuntimeError` pointing at the right requirements file instead of a raw `ModuleNotFoundError`.

## Docs and tests
- README, getting-started, voice-and-tts, cli-reference, and CLAUDE.md updated to cover the engine choice and optional installs.
- Tests added for the ElevenLabs backend, CLI routing/validation, and the missing-dependency errors. Full suite: 391 passing.

## Note
A fresh clone that runs `python -m deck2video deck.md` without going through `setup.sh` will hit the friendly "install Chatterbox" error rather than working, since the default engine is no longer installed automatically. This is the tradeoff for a leaner default install; the error message tells the user how to fix it.